### PR TITLE
cp2k_engine running shooting points asynchronously

### DIFF
--- a/transition_sampling/engines/CP2K_engine.py
+++ b/transition_sampling/engines/CP2K_engine.py
@@ -1,18 +1,28 @@
 """
 Engine implementation of CP2K
 """
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+import uuid
 from typing import Sequence
+
 import numpy as np
+from cp2k_input_tools.generator import CP2KInputGenerator
 from cp2k_input_tools.parser import CP2KInputParser
+from cp2k_output_tools.blocks.warnings import match_warnings
 
 from .abstract_engine import AbstractEngine, ShootingResult
 
 
 class CP2KEngine(AbstractEngine):
-    def __init__(self, inputs):
-        super().__init__(inputs)
+    def __init__(self, inputs, working_dir=None):
+        super().__init__(inputs, working_dir)
 
         self._atoms = None
+        self.cmd = inputs["cmd"].split()
         with open(inputs["cp2k_inputs"]) as f:
             parser = CP2KInputParser()
             self.cp2k_inputs = parser.parse(f)
@@ -66,7 +76,99 @@ class CP2KEngine(AbstractEngine):
         return super().validate_inputs(inputs)
 
     async def run_shooting_point(self) -> ShootingResult:
-        pass
+        # random project name so we don't overwrite/appened anything
+        proj_name = uuid.uuid4().hex
+
+        tasks = self._launch_traj_fwd(proj_name), \
+                self._launch_traj_rev(proj_name)
+
+        # Wait until both tasks are complete
+        result = await asyncio.gather(asyncio.gather(*tasks))
+
+    async def _launch_traj_fwd(self, projname: str):
+        """Launch a trajectory in the forwards direction
+
+        Parameters
+        ----------
+        projname
+            Root project name
+        """
+        return await self._launch_traj(projname + "_fwd")
+
+    async def _launch_traj_rev(self, projname: str):
+        """Launch a trajectory in the reverse direction
+
+        Parameters
+        ----------
+        projname
+            Root project name
+        """
+        # Flip the velocity. This could cause a problem if we ever parallelize
+        # this method with shared memory, but shouldn't be a problem with
+        # completely new proc or asyncio (current implementation)
+        self.flip_velocity()
+        return await self._launch_traj(projname + "_rev")
+
+    async def _launch_traj(self, projname: str):
+        """Launch a trajectory with the current state to completion.
+
+        Launch a trajectory using the current state with the given command in
+        a new process. Runs in the given working directory. Waits for its
+        completion with async, then checks for failures or warnings.
+
+        Parameters
+        ----------
+        projname
+            The unique project name. No other project should have this name
+
+        Returns
+        -------
+        TODO: Parsing output
+        """
+        # Assign the unique project name
+        self.cp2k_inputs["+global"]["project_name"] = projname
+
+        # Write the input to the working directory location
+        input_path = os.path.join(self.working_dir, f"{projname}.inp")
+        write_cp2k_input(self.cp2k_inputs, input_path)
+
+        # Start cp2k, expanding the list of commands and setting input/output
+        proc = subprocess.Popen([*self.cmd, "-i", input_path, "-o",
+                                 f"{projname}.out"],
+                                cwd=self.working_dir,
+                                stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE)
+
+        # Wait for it to finish
+        while proc.poll() is None:
+            # Non-blocking sleep
+            await asyncio.sleep(1)
+
+        # Create an output handler for errors and warnings
+        output_handler = CP2KOutputHandler(projname, self.working_dir)
+
+        # Check if there was a fatal error
+        if proc.returncode != 0:
+            stdout, stderr = proc.communicate()
+
+            # Copy the output file to a place we can see it
+            # TODO copy more info (pos)
+            output_file = f"{projname}_FATAL.out"
+            output_handler.copy_out_file(output_file)
+
+            # Append the error from stdout to the output file
+            with open(output_file, "a") as f:
+                f.write(stdout.decode('ascii'))
+
+            # TODO: Better exception
+            raise Exception("Process failed")
+
+        # Get the output file for warnings. If there are some, log them
+        warnings = output_handler.check_warnings()
+        if len(warnings) != 0:
+            # TODO: Log warnings better
+            logging.warning("CP2K run of %s generated warnings: %s",
+                            projname, warnings)
 
     @property
     def delta_t(self) -> float:
@@ -79,33 +181,122 @@ class CP2KEngine(AbstractEngine):
     def get_engine_str(self) -> str:
         return "cp2k"
 
-    def _get_subsys(self) -> dict:
+    def flip_velocity(self) -> None:
+        """Modify state by multiplying every velocity component by -1
         """
-        Gets the subsys section of the stored cp2k inputs
-        :return: Subsys dictionary
+        vel = self._get_velocity()
+        for i in range(len(vel)):
+            for j in range(3):
+                vel[i][j] = -1 * vel[i][j]
+
+    def _get_subsys(self) -> dict:
+        """Gets the subsys section of the stored cp2k inputs
+
+        This is a direct reference that can be used to modify the state.
+
+        Returns
+        -------
+        subsys dictionary
         """
         return self.cp2k_inputs["+force_eval"][0]["+subsys"]
 
-    def _get_coord(self) -> list:
-        """
-        Gets the coord section of the stored cp2k inputs. Represented as a list
-        of strings, where each string follows the .xyz format of
-        "El x y z"
-        :return: Coord list of strings
+    def _get_coord(self) -> Sequence[str]:
+        """Gets the coord section of the stored cp2k inputs.
+
+        Coordinates are represented as a list of strings, where each string
+        follows the .xyz format of "El x y z".
+
+        This is a direct reference that can be used to modify the state.
+
+        Returns
+        -------
+            Coord list of strings
         """
         return self._get_subsys()["+coord"]["*"]
 
     def _get_velocity(self) -> list:
-        """
-        Gets the velocity section of the stored cp2k inputs. Represented as a
-        list of lists, where the outer index is the atom and the inner index
-        is the floats of x, y, z. If this section hasn't been initialized in
-        subsys, it is created with the correct length and zeros for all entries
-        :return: Velocities as a list of lists
+        """Gets the velocity section of the stored cp2k inputs.
+
+        Velocities are represented as a list of lists, where the outer index
+        is the atom and the inner index is the floats of x, y, z. If this
+        section hasn't been initialized in subsys, it is created with the
+        correct length and zeros for all entries.
+
+        This is a direct reference that can be used to modify the state.
+
+        Returns
+        -------
+        Velocities as a list of lists
         """
         subsys = self._get_subsys()
         if "+velocity" not in subsys:
-            subsys["+velocity"] = {"*": [[0, 0, 0] for i in range(len(self.atoms))]}
+            subsys["+velocity"] = {
+                "*": [[0, 0, 0] for i in range(len(self.atoms))]}
 
         return subsys["+velocity"]["*"]
 
+
+def write_cp2k_input(cp2k_inputs: dict, filename: str) -> None:
+    """Write the current state of cp2k inputs to the passed file name.
+
+    Creates the standard cp2k input format. Overwrites anything present.
+
+    Parameters
+    ----------
+    cp2k_inputs
+        Dictionary of cp2k inputs created by the parser
+    filename
+        The file to write the input to
+    """
+    with open(filename, 'w') as f:
+        cp2k_gen = CP2KInputGenerator()
+        for line in cp2k_gen.line_iter(cp2k_inputs):
+            f.write(f"{line}\n")
+
+
+class CP2KOutputHandler:
+    def __init__(self, name: str, working_dir: str):
+        """Parses CP2K output to check for errors or warnings.
+
+        Parameters
+        ----------
+        name
+            name of the project that everything is prefixed with
+        working_dir
+            the directory all output files are located in
+        """
+        self.name = name
+        self.working_dir = working_dir
+
+    def check_warnings(self) -> Sequence:
+        """Check the output file for any warnings.
+
+        Returns a list of warnings. The list is empty if there are none.
+
+        Returns
+        -------
+        A list of warnings from this output file
+        """
+        with open(self.get_out_file(), "r") as f:
+            warnings = match_warnings(f.read())
+
+        return warnings['warnings']
+
+    def get_out_file(self) -> str:
+        """Get the full name of the output file
+
+        Returns
+        -------
+        Full path of output file
+        """
+        return os.path.join(self.working_dir, f"{self.name}.out")
+
+    def copy_out_file(self, new_location: str) -> None:
+        """Copy the output file to a new location
+
+        Parameters
+        ----------
+        new_location
+            The full path of the location to copy to
+        """
+        shutil.copyfile(self.get_out_file(), new_location)

--- a/transition_sampling/engines/CP2K_engine.py
+++ b/transition_sampling/engines/CP2K_engine.py
@@ -18,7 +18,7 @@ from .abstract_engine import AbstractEngine, ShootingResult
 
 
 class CP2KEngine(AbstractEngine):
-    def __init__(self, inputs, working_dir=None):
+    def __init__(self, inputs: dict, working_dir: str = None):
         super().__init__(inputs, working_dir)
 
         self._atoms = None
@@ -76,11 +76,11 @@ class CP2KEngine(AbstractEngine):
         return super().validate_inputs(inputs)
 
     async def run_shooting_point(self) -> ShootingResult:
-        # random project name so we don't overwrite/appened anything
+        # random project name so we don't overwrite/append anything
         proj_name = uuid.uuid4().hex
 
-        tasks = self._launch_traj_fwd(proj_name), \
-                self._launch_traj_rev(proj_name)
+        tasks = (self._launch_traj_fwd(proj_name),
+                 self._launch_traj_rev(proj_name))
 
         # Wait until both tasks are complete
         result = await asyncio.gather(asyncio.gather(*tasks))
@@ -103,8 +103,8 @@ class CP2KEngine(AbstractEngine):
         projname
             Root project name
         """
-        # Flip the velocity. This could cause a problem if we ever parallelize
-        # this method with shared memory, but shouldn't be a problem with
+        # Flip the velocity. This could cause an issue if we ever parallelize
+        # this method with shared memory, but shouldn't be a problem with a
         # completely new proc or asyncio (current implementation)
         self.flip_velocity()
         return await self._launch_traj(projname + "_rev")

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -26,23 +26,37 @@ class AbstractEngine(ABC):
 
     @abstractmethod
     def __init__(self, inputs: dict, working_dir: str = None):
-        """
-        Create an engine by passing the required inputs and a working directory.
-        Inputs are engine specific.
+        """Create an engine.
 
-        :param inputs: Dictionary of inputs required for the engine. See engine
-            specific documentation for more detail.
-        :param working_dir: The directory that all temporary input/output files
-            will be placed in.
+        Pass the required inputs and a working directory for the engine to write
+        files to. Inputs are engine specific.
+
+        Parameters
+        ----------
+        inputs
+            Dictionary of inputs required for the engine. See engine specific
+            documentation for more detail.
+        working_dir
+            The directory that all temporary input/output files will be placed
+            in. If not specified or is None, defaults to the current directory.
+
+        Raises
+        ------
+        ValueError
+            if inputs are not valid for the concrete engine class or if a given
+            working directory is not a real directory.
         """
         validation_res = self.validate_inputs(inputs)
         if not validation_res[0]:
             raise ValueError(f"Invalid inputs: {validation_res[1]}")
 
-        # TODO: handle none case
         if working_dir is not None and not os.path.isdir(working_dir):
             raise ValueError(f"{working_dir} is not a directory")
-        self.working_dir = working_dir
+
+        if working_dir is None:
+            self.working_dir = "."
+        else:
+            self.working_dir = working_dir
 
     @property
     @abstractmethod
@@ -171,7 +185,7 @@ class AbstractEngine(ABC):
         """Set the time offset of this engine.
 
         Set the value of the time offset of frame to save in seconds. If this
-        isn't a multiple of the engine's timestep, the closest frame will be
+        isn't a multiple of the engine's time step, the closest frame will be
         taken.
 
         Parameters

--- a/transition_sampling/tests/engine_tests/test_CP2K_engine.py
+++ b/transition_sampling/tests/engine_tests/test_CP2K_engine.py
@@ -6,10 +6,12 @@ from unittest import TestCase
 import numpy as np
 
 from engines import CP2KEngine
+from engines.CP2K_engine import write_cp2k_input
 
 ENG_STR = "cp2k"
 cur_dir = os.path.dirname(__file__)
 TEST_INPUT = os.path.join(cur_dir, "test_data/test_cp2k.inp")
+TEST_CMD = "test cmd"
 
 
 # Parsing the input into memory for every test makes these pretty slow ~1s each,
@@ -25,7 +27,8 @@ class CP2KEngineTestCase(TestCase):
 
     def setUp(self) -> None:
         self.engine = CP2KEngine({"engine": ENG_STR,
-                                  "cp2k_inputs": TEST_INPUT})
+                                  "cp2k_inputs": TEST_INPUT,
+                                  "cmd": TEST_CMD})
         self.assertEqual(len(self.engine.atoms), 2)
 
 
@@ -37,12 +40,29 @@ class TestCP2KEngineValidation(TestCase):
         # Invalid name will raise exception
         with self.assertRaises(ValueError, msg="Empty engine name should fail"):
             e = CP2KEngine({"engine": "",
+                            "cp2k_inputs": TEST_INPUT,
+                            "cmd": TEST_CMD})
+
+        # Valid engine name should pass
+        e = CP2KEngine({"engine": ENG_STR,
+                        "cp2k_inputs": TEST_INPUT,
+                        "cmd": TEST_CMD})
+        self.assertIsNotNone(e, f"{ENG_STR} should be valid")
+
+    def test_cmd(self):
+        """
+        Command should be a string
+        """
+        # Invalid name will raise exception
+        with self.assertRaises(ValueError, msg="Empty engine name should fail"):
+            e = CP2KEngine({"engine": ENG_STR,
                             "cp2k_inputs": TEST_INPUT})
 
         # Valid engine name should pass
         e = CP2KEngine({"engine": ENG_STR,
-                        "cp2k_inputs": TEST_INPUT})
-        self.assertIsNotNone(e, f"{ENG_STR} should be valid")
+                        "cp2k_inputs": TEST_INPUT,
+                        "cmd": TEST_CMD})
+        self.assertIsNotNone(e, f"{TEST_CMD} should be valid")
 
     def test_missing_input_file(self):
         """
@@ -51,13 +71,15 @@ class TestCP2KEngineValidation(TestCase):
         # Missing input field
         with self.assertRaises(ValueError,
                                msg="Missing input field should fail"):
-            e = CP2KEngine({"engine": ENG_STR})
+            e = CP2KEngine({"engine": ENG_STR,
+                            "cmd": TEST_CMD})
 
         # Input file does not exist
         with self.assertRaises(ValueError,
                                msg="Non-existent input file should fail"):
             e = CP2KEngine({"engine": ENG_STR,
-                            "cp2k_inputs": "non_existent_file"})
+                            "cp2k_inputs": "non_existent_file",
+                            "cmd": TEST_CMD})
 
     def test_invalid_input_file(self):
         """
@@ -78,14 +100,16 @@ class TestCP2KEngineValidation(TestCase):
             with self.assertRaises(ValueError,
                                    msg="Invalid CP2K input should fail"):
                 e = CP2KEngine({"engine": ENG_STR,
-                                "cp2k_inputs": temp_file.name})
+                                "cp2k_inputs": temp_file.name,
+                                "cmd": TEST_CMD})
 
     def test_valid_input_file(self):
         """
         Provided input file should be valid
         """
         self.assertIsNotNone(CP2KEngine({"engine": ENG_STR,
-                                         "cp2k_inputs": TEST_INPUT}),
+                                         "cp2k_inputs": TEST_INPUT,
+                                         "cmd": TEST_CMD}),
                              msg="Test input should be valid")
 
 
@@ -137,12 +161,37 @@ class TestCP2KEnginePositions(CP2KEngineTestCase):
 
         self.engine.set_positions(pos)
 
-        # Internal Representation of stored positions for CP2K
-        stored_pos = \
-            self.engine.cp2k_inputs["+force_eval"][0]["+subsys"]["+coord"]["*"]
+        self._compare_positions(pos, self.engine)
+
+    def test_set_positions_and_write(self):
+        """
+        Assign positions, write to a file, load into a new engine, and see if
+        they match
+        """
+        pos = np.array([[1.0021, 123.123, 6.23123],
+                        [8.12, 6.12381, 0.1232]])
+
+        self.engine.set_positions(pos)
+        with tempfile.NamedTemporaryFile() as temp_file:
+            write_cp2k_input(self.engine.cp2k_inputs, temp_file.name)
+
+            new_engine = CP2KEngine({"engine": ENG_STR,
+                                     "cp2k_inputs": temp_file.name,
+                                     "cmd": TEST_CMD})
+
+            self._compare_positions(pos, new_engine)
+
+    def _compare_positions(self, expected, engine):
+        """
+        Compare expected positions to those actually stored by an engine
+        :param expected: Array of expected positions
+        :param engine: Engine to compare to
+        """
+        actual = \
+            engine.cp2k_inputs["+force_eval"][0]["+subsys"]["+coord"]["*"]
 
         # Iterate over each stored and assigned position to compare
-        for s, p in zip(stored_pos, pos):
+        for s, p in zip(actual, expected):
             # Convert string representation to list of floats
             split_list = [float(num) for num in s[3:].split()]
             # Convert numpy array to list for assertListEquals
@@ -153,7 +202,7 @@ class TestCP2KEnginePositions(CP2KEngineTestCase):
 class TestCP2KEngineVelocities(CP2KEngineTestCase):
     def test_set_velocities_wrong_num_atoms(self):
         """
-        Test there must be exactly one velocityector for each atom
+        Test there must be exactly one velocity vector for each atom
         """
         vel = np.array([[1.0021, 123.123, 1.2012]])
 
@@ -172,7 +221,7 @@ class TestCP2KEngineVelocities(CP2KEngineTestCase):
                                msg="There should be an x,y,z for each atom"):
             self.engine.set_velocities(vel)
 
-    def test_set_positions_valid(self):
+    def test_set_velocities_valid(self):
         """
         Assign valid velocities and check the internal representation of them
         """
@@ -180,14 +229,40 @@ class TestCP2KEngineVelocities(CP2KEngineTestCase):
                         [8.12, 6.12381, 0.1232]])
 
         self.engine.set_velocities(vel)
+        self._compare_velocities(vel, self.engine)
 
+    def test_set_velocities_and_write(self):
+        """
+        Assign velocities, write to a file, load into a new engine, and see if
+        they match
+        """
+        vel = np.array([[1.0021, 123.123, 6.23123],
+                        [8.12, 6.12381, 0.1232]])
+
+        self.engine.set_velocities(vel)
+
+        with tempfile.NamedTemporaryFile() as temp_file:
+            write_cp2k_input(self.engine.cp2k_inputs, temp_file.name)
+
+            new_engine = CP2KEngine({"engine": ENG_STR,
+                                     "cp2k_inputs": temp_file.name,
+                                     "cmd": TEST_CMD})
+
+            self._compare_velocities(vel, new_engine)
+
+    def _compare_velocities(self, expected, engine):
+        """
+        Compare the expected values of a velocity to those actually stored by
+        an engine
+        :param expected: array of expected velocities
+        :param engine: engine to check if velocities match
+        """
         # Internal Representation of stored positions for CP2K
-        stored_vel = \
-            self.engine.cp2k_inputs["+force_eval"][0]["+subsys"]["+velocity"][
-                "*"]
+        actual = \
+            engine.cp2k_inputs["+force_eval"][0]["+subsys"]["+velocity"]["*"]
 
         # Iterate over each stored and assigned position to compare
-        for s, v in zip(stored_vel, vel):
+        for s, v in zip(actual, expected):
             # Convert numpy array to list for assertListEquals
             v = v.tolist()
             self.assertListEqual(v, s, "Velocities were not equal")

--- a/transition_sampling/tests/engine_tests/test_data/test_cp2k_warnings.out
+++ b/transition_sampling/tests/engine_tests/test_data/test_cp2k_warnings.out
@@ -1,0 +1,257 @@
+ DBCSR| Multiplication driver                                               XSMM
+ DBCSR| Multrec recursion limit                                              512
+ DBCSR| Multiplication stack size                                           1000
+ DBCSR| Maximum elements for images                                    UNLIMITED
+ DBCSR| Multiplicative factor virtual images                                   1
+ DBCSR| Multiplication size stacks                                             3
+ DBCSR| Number of 3D layers                                               SINGLE
+ DBCSR| Use MPI memory allocation                                              T
+ DBCSR| Use RMA algorithm                                                      F
+ DBCSR| Use Communication thread                                               T
+ DBCSR| Communication thread load                                             87
+
+
+  **** **** ******  **  PROGRAM STARTED AT               2020-12-03 14:27:35.337
+ ***** ** ***  *** **   PROGRAM STARTED ON                      n2155.hyak.local
+ **    ****   ******    PROGRAM STARTED BY                                lemmoi
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 14738
+  **** **  *******  **  PROGRAM STARTED IN /gscratch/pfaendtner/lemmoi/transitio
+                                           n-sampling/transition_sampling/engine
+                                           s/tmp
+
+ CP2K| version string:                    CP2K version 6.0 (Development Version)
+ CP2K| source code revision number:                                  git:114ba9e
+ CP2K| cp2kflags: omp libint fftw3 libxc elpa=201605 elpa_qr parallel mpi3 scala
+ CP2K|            pack xsmm has_no_shared_glibc libderiv_max_am1=5 libint_max_am=6 max_contr=4 plumed2 mkl
+ CP2K| is freely available from                            https://www.cp2k.org/
+ CP2K| Program compiled at                           Fri Apr 6 10:52:09 PDT 2018
+ CP2K| Program compiled on                                      n2133.hyak.local
+ CP2K| Program compiled for                                   Linux-x86-64-intel
+ CP2K| Data directory path        /gscratch/pfaendtner/codes/cp2k/cp2k/cp2k/data
+ CP2K| Input file name        /gscratch/pfaendtner/lemmoi/transition-sampling/tr
+ 
+ GLOBAL| Force Environment number                                              1
+ GLOBAL| Basis set file name                                           BASIS_SET
+ GLOBAL| Potential file name                                           POTENTIAL
+ GLOBAL| MM Potential file name                                     MM_POTENTIAL
+ GLOBAL| Coordinate file name                                      __STD_INPUT__
+ GLOBAL| Method name                                                        CP2K
+ GLOBAL| Project name                       8eca04b682b54e9cad1f6f36ea4efc57_rev
+ GLOBAL| Preferred FFT library                                             FFTW3
+ GLOBAL| Preferred diagonalization lib.                                       SL
+ GLOBAL| Run type                                                             MD
+ GLOBAL| All-to-all communication in single precision                          F
+ GLOBAL| FFTs using library dependent lengths                                  F
+ GLOBAL| Global print level                                               MEDIUM
+ GLOBAL| Total number of message passing processes                             2
+ GLOBAL| Number of threads for this process                                    1
+ GLOBAL| This output is from process                                           0
+ GLOBAL| CPU model name :  Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
+
+ MEMORY| system memory details [Kb]
+ MEMORY|                        rank 0           min           max       average
+ MEMORY| MemTotal            131316396     131316396     131316396     131316396
+ MEMORY| MemFree             117659004     117659004     117659500     117659252
+ MEMORY| Buffers                     0             0             0             0
+ MEMORY| Cached                 666264        666264        666264        666264
+ MEMORY| Slab                   403404        403404        403404        403404
+ MEMORY| SReclaimable           125620        125620        125620        125620
+ MEMORY| MemLikelyFree       118450888     118450888     118451384     118451136
+
+
+ *** Fundamental physical constants (SI units) ***
+
+ *** Literature: B. J. Mohr and B. N. Taylor,
+ ***             CODATA recommended values of the fundamental physical
+ ***             constants: 2006, Web Version 5.1
+ ***             http://physics.nist.gov/constants
+
+ Speed of light in vacuum [m/s]                             2.99792458000000E+08
+ Magnetic constant or permeability of vacuum [N/A**2]       1.25663706143592E-06
+ Electric constant or permittivity of vacuum [F/m]          8.85418781762039E-12
+ Planck constant (h) [J*s]                                  6.62606896000000E-34
+ Planck constant (h-bar) [J*s]                              1.05457162825177E-34
+ Elementary charge [C]                                      1.60217648700000E-19
+ Electron mass [kg]                                         9.10938215000000E-31
+ Electron g factor [ ]                                     -2.00231930436220E+00
+ Proton mass [kg]                                           1.67262163700000E-27
+ Fine-structure constant                                    7.29735253760000E-03
+ Rydberg constant [1/m]                                     1.09737315685270E+07
+ Avogadro constant [1/mol]                                  6.02214179000000E+23
+ Boltzmann constant [J/K]                                   1.38065040000000E-23
+ Atomic mass unit [kg]                                      1.66053878200000E-27
+ Bohr radius [m]                                            5.29177208590000E-11
+
+ *** Conversion factors ***
+
+ [u] -> [a.u.]                                              1.82288848426455E+03
+ [Angstrom] -> [Bohr] = [a.u.]                              1.88972613288564E+00
+ [a.u.] = [Bohr] -> [Angstrom]                              5.29177208590000E-01
+ [a.u.] -> [s]                                              2.41888432650478E-17
+ [a.u.] -> [fs]                                             2.41888432650478E-02
+ [a.u.] -> [J]                                              4.35974393937059E-18
+ [a.u.] -> [N]                                              8.23872205491840E-08
+ [a.u.] -> [K]                                              3.15774647902944E+05
+ [a.u.] -> [kJ/mol]                                         2.62549961709828E+03
+ [a.u.] -> [kcal/mol]                                       6.27509468713739E+02
+ [a.u.] -> [Pa]                                             2.94210107994716E+13
+ [a.u.] -> [bar]                                            2.94210107994716E+08
+ [a.u.] -> [atm]                                            2.90362800883016E+08
+ [a.u.] -> [eV]                                             2.72113838565563E+01
+ [a.u.] -> [Hz]                                             6.57968392072181E+15
+ [a.u.] -> [1/cm] (wave numbers)                            2.19474631370540E+05
+ [a.u./Bohr**2] -> [1/cm]                                   5.14048714338585E+03
+ 
+
+
+                      ************* ******** ***********   
+                     ************* **********************  
+                     ****     **** ****      ***********   
+                     ******** ****  *******     ****       
+                     *******  ****   *******   ****        
+                     ****     ****       ****  ****        
+                     ****     **** **********  ****        
+                      ****     **** ********    ****       
+                     FRONTIERS IN SIMULATION TECHNOLOGY    
+                                                           
+                        C.J. Mundy, S. Balasubramanian,    
+                     Ken Bagchi, J. Hutter, Ari Seitsonen  
+                      IFW Kuo, T. Laino, J. VandeVondele   
+                                 Version 1.0               
+
+                                                           
+
+
+ CELL| Volume [angstrom^3]:                                             5051.263
+ CELL| Vector a [angstrom]:      17.158     0.000     0.000    |a| =      17.158
+ CELL| Vector b [angstrom]:       0.000    17.158     0.000    |b| =      17.158
+ CELL| Vector c [angstrom]:       0.000     0.000    17.158    |c| =      17.158
+ CELL| Angle (b,c), alpha [degree]:                                       90.000
+ CELL| Angle (a,c), beta  [degree]:                                       90.000
+ CELL| Angle (a,b), gamma [degree]:                                       90.000
+ CELL| Numerically orthorhombic:                                             YES
+
+ CELL_REF| Volume [angstrom^3]:                                         5051.263
+ CELL_REF| Vector a [angstrom    17.158     0.000     0.000    |a| =      17.158
+ CELL_REF| Vector b [angstrom     0.000    17.158     0.000    |b| =      17.158
+ CELL_REF| Vector c [angstrom     0.000     0.000    17.158    |c| =      17.158
+ CELL_REF| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_REF| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_REF| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_REF| Numerically orthorhombic:                                         YES
+ EWALD|                                                                 not used
+
+ CELL_TOP| Volume [angstrom^3]:                                         5051.263
+ CELL_TOP| Vector a [angstrom    17.158     0.000     0.000    |a| =      17.158
+ CELL_TOP| Vector b [angstrom     0.000    17.158     0.000    |b| =      17.158
+ CELL_TOP| Vector c [angstrom     0.000     0.000    17.158    |c| =      17.158
+ CELL_TOP| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_TOP| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_TOP| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_TOP| Numerically orthorhombic:                                         YES
+ 
+ GENERATE|  Preliminary Number of Bonds generated:                             0
+ GENERATE|  Achieved consistency in connectivity generation.
+ CHARGE_INFO| Total Charge of the Classical System:                     0.000000
+ 
+ FORCEFIELD| WARNING: A non Critical ForceField parameter is missing! CP2K GOES!
+ FORCEFIELD| Non critical parameters are:Urey-Bradley,Torsions,Impropers, Opbends and 1-4
+ FORCEFIELD| All missing parameters will not contribute to the potential energy!
+ FORCEFIELD| Activate the print key FF_INFO to have a list of missing parameters
+ 
+
+ SPLINE_INFO| Generating 1 splines for NONBONDED14 interactions 
+              Due to 1 different atomic kinds
+  ...1
+ SPLINE_INFO| Number of unique splines computed:            1
+ SPLINE_INFO| Done
+
+ SPLINE_INFO| Generating 1 splines for NONBONDED interactions 
+              Due to 1 different atomic kinds
+  ...1
+ SPLINE_INFO| Number of unique splines computed:            1
+ SPLINE_INFO| Done
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ MODULE FIST:  ATOMIC COORDINATES IN ANGSTROM
+
+  Atom  Kind  ATM_TYP       X           Y           Z          q(eff)       Mass
+
+     1    1   Ar        -8.000000    0.000000    0.000000      0.00      39.9480
+     2    1   Ar         0.000000    0.000000    0.000000      0.00      39.9480
+
+
+ 
+ MD| Molecular Dynamics Protocol 
+ MD| Ensemble Type                                                           NVE
+ MD| Number of Time Steps                                                     20
+ MD| Time Step [fs]                                                         5.00
+ MD| Temperature [K]                                                       85.00
+ MD| Temperature tolerance [K]                                              0.00
+ MD| Print MD information every                                        1 step(s)
+ MD| File type     Print frequency[steps]                             File names
+ MD| Coordinates            1     8eca04b682b54e9cad1f6f36ea4efc57_rev-pos-1.xyz
+ MD| Velocities             1     8eca04b682b54e9cad1f6f36ea4efc57_rev-vel-1.xyz
+ MD| Energies               1        8eca04b682b54e9cad1f6f36ea4efc57_rev-1.ener
+ MD| Dump                  20     8eca04b682b54e9cad1f6f36ea4efc57_rev-1.restart
+ 
+ ROT| Rotational Analysis Info 
+ ROT| Principal axes and moments of inertia in atomic units:
+ ROT|                                1                 2                 3
+ ROT| EIGENVALUES            0.000000000E+00   0.832152378E+07   0.832152378E+07
+ ROT|      X                     1.000000000       0.000000000       0.000000000
+ ROT|      Y                     0.000000000       1.000000000       0.000000000
+ ROT|      Z                     0.000000000       0.000000000       1.000000000
+ ROT| Numer of Rotovibrational vectors:     5
+ ROT| Linear Molecule detected..
+
+ Calculation of degrees of freedom
+                                                      Number of atoms:         2
+                                 Number of Intramolecular constraints:         0
+                                 Number of Intermolecular constraints:         0
+                                  Invariants(translation + rotations):         3
+                                                   Degrees of freedom:         3
+
+
+ Restraints Information
+                                  Number of Intramolecular restraints:         0
+                                  Number of Intermolecular restraints:         0
+ ************************** Velocities initialization **************************
+ Initial Temperature                                              296843266.98 K
+ COM velocity:           -0.012559821070      0.023656197863      0.134094372538
+ *******************************************************************************
+
+ MM DIPOLE [BERRY PHASE](A.U.)|                   0.000000   0.000000   0.000000
+ MM DIPOLE [BERRY PHASE](Debye)|                  0.000000   0.000000   0.000000
+ MM DIPOLE [BERRY PHASE] DERIVATIVE(A.U.)|        0.000000   0.000000   0.000000
+
+ ENERGY| Total FORCE_EVAL ( FIST ) energy (a.u.):             -0.000002339066347
+
+
+ *** WARNING in input/cp_parser_methods.F:1258 :: The input string          ***
+ *** </gscratch/pfaendtner/lemmoi/transition-sampling/transition_sampling/e ***
+ *** gines/plumed.dat> has more than     80 characters and is therefore     ***
+ *** too long to fit in the specified variable, File:                       ***
+ *** '/gscratch/pfaendtner/lemmoi/transition-sampling/transition_sampling/e ***
+ *** gines/tmp/8eca04b682b54e9cad1f6f36ea4efc57_rev.inp', Line: 16,         ***
+ *** Column: 11, Chunk:                                                     ***
+ *** </gscratch/pfaendtner/lemmoi/transition-sampling/transition_sampling/e ***
+ *** gines/plumed.dat>                                                      ***
+
+
+===================================================================================
+=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
+=   PID 14739 RUNNING AT n2155
+=   EXIT CODE: 6
+=   CLEANING UP REMAINING PROCESSES
+=   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
+===================================================================================
+   Intel(R) MPI Library troubleshooting guide:
+      https://software.intel.com/node/561764
+===================================================================================


### PR DESCRIPTION
This PR lets us run a shooting point from cp2k by going forwards and backwards in parallel. In python, this is done with `asyncio`, where each trajectory is opened in a new process, then `await`ed to be complete, allowing other things to be done in python while waiting for the spawned trajectories are completed.

 Each pair of trajectories is given a unique project name, then appended with `_fwd` and `_rev`. _Open to suggestions here._ All files generated by cp2k are written to the passed working directory. 

If a trajectory has a fatal error (non-zero return code), an exception is thrown and the output file is copied to the current directory (wherever python was invoked from).

Once complete, the output is parsed for any warnings, which are currently logged if they exist. Currently nothing else is done with the output.

Out of scope:
 - parsing the output for anything useful
 - integration with plumed (but not hard, so will be paired with the above)
 - testing running cp2k. hard problem