### PR TITLE
Text documentation for cp2k thus far

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ sys.setrecursionlimit(1500)
 
 # -- Project information -----------------------------------------------------
 
-project = 'transition-sampling'
+project = 'transition_sampling'
 copyright = '2020, Isaiah Lemmon'
 author = 'Isaiah Lemmon'
 

--- a/docs/source/engines/cp2k.rst
+++ b/docs/source/engines/cp2k.rst
@@ -1,0 +1,14 @@
+CP2K Documentation
+==================
+
+..  toctree::
+    :maxdepth: 1
+
+CP2K Specific Inputs
+--------------------
+In addition to the inputs required by all :doc:`engines <engines>`, the CP2K specific inputs are listed below.
+
+``cp2k_inputs`` - path of the CP2K input file
+    The path to a well formed CP2K input file that describes the system you want to run. This original file will not be
+    modified. An exception will be thrown if this does not pass the linter provided by
+    `cp2k-input-tools <https://github.com/cp2k/cp2k-input-tools>`_

--- a/docs/source/engines/engines.rst
+++ b/docs/source/engines/engines.rst
@@ -1,0 +1,46 @@
+MD Engines
+==========
+Below are all currently supported engines to generate shooting points with.
+
+..  toctree::
+    :maxdepth: 2
+    :caption: Available Engines:
+
+    CP2K <cp2k>
+
+Intro to Engines
+----------------
+All engines share some common features that need to be specified in
+the inputs. In particular, these are
+
+``engine`` -  the engine name
+    String defined by the engine implementation of the method
+    :func:`~transition_sampling.engines.abstract_engine.AbstractEngine.get_engine_str`
+
+    Example:
+
+    * ``"engine": "cp2k"`` - use the cp2k engine implementation
+
+``cmd`` - the command line command to invoke the engine
+    The string you would use to run the MD engine from the command line normally, leading
+    up to the path of the engine executable. Any additional commands (such as ``mpirun``)
+    can be prepended, but the final argument should be the engine executable.
+
+    ..  warning::
+        You should not rely on relative paths of executables. They should either be
+        in the PATH environment variable when invoked, or the full path should be given.
+
+    Examples of valid commands:
+
+    * ``"cmd": "/path/to/cp2k/exec"`` - just use the standard cp2k executable.
+    * ``"cmd": "mpirun -n 2 -genv 1 /path/to/cp2k/exec"`` -  Run cp2k with MPI with two processes
+
+        ..  note::
+            Since the aimless shooting algorithm runs the forwards and backwards trajectories
+            in parallel, the ideal number of MPI processes is equal to ``num_cores/2``, so
+            cores are distributed evenly across the two trajectories.
+
+    Examples of **invalid** commands:
+
+    * ``"cmd": "/path/to/cp2k/exec -i my_input_file -o my_output_file"`` - arguments after the engine executable should be left to the module
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,14 @@
-Welcome to test_proj's documentation!
-=====================================
+Welcome to transition_sampling's documentation!
+===============================================
 
-.. toctree::
-   :maxdepth: 4
-   :caption: Contents:
+..  toctree::
+    :maxdepth: 1
+    :caption: Contents:
 
-   modules
+    engines/engines
+    transition_sampling
+
+
 
 
 

--- a/docs/source/transition_sampling.rst
+++ b/docs/source/transition_sampling.rst
@@ -1,5 +1,5 @@
-transition\_sampling package
-============================
+transition\_sampling API
+========================
 
 Subpackages
 -----------


### PR DESCRIPTION
Starts the framework for adding more user-level documentation for CP2K as it gets added, as well as documentation specifics thus far.