### PR TITLE
Temperature added as an engine requirement

### DIFF
--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -151,6 +151,17 @@ class AbstractEngine(ABC):
         """
         pass
 
+    @property
+    @abstractmethod
+    def temp(self) -> float:
+        """Get the temperature of the engine in Kelvin.
+
+        Returns
+        -------
+        Temperature the engine is set to in Kelvin
+        """
+        pass
+
     @abstractmethod
     def set_positions(self, positions: np.ndarray) -> None:
         """Set the positions of atoms in the engine.

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -53,6 +53,10 @@ class CP2KEngine(AbstractEngine):
     def atoms(self) -> Sequence[str]:
         return self.cp2k_inputs.atoms
 
+    @property
+    def temp(self) -> float:
+        return self.cp2k_inputs.temp
+
     def set_positions(self, positions: np.ndarray) -> None:
         # Check positions are valid by passing to base class
         super().set_positions(positions)
@@ -227,4 +231,3 @@ class CP2KEngine(AbstractEngine):
         pattern = os.path.join(self.working_dir, "core.*")
         for file in glob.glob(pattern):
             os.remove(file)
-

--- a/transition_sampling/engines/cp2k/CP2K_inputs.py
+++ b/transition_sampling/engines/cp2k/CP2K_inputs.py
@@ -50,6 +50,16 @@ class CP2KInputsHandler:
 
         return self._atoms
 
+    @property
+    def temp(self) -> float:
+        """Get the temperature of the input.
+
+        Returns
+        -------
+        Temperature the input is set to in Kelvin
+        """
+        return self.cp2k_dict["+motion"]["+md"]["temperature"]
+
     def set_positions(self, positions: np.ndarray) -> None:
         """Set the positions of atoms in the inputs.
 

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_engine.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_engine.py
@@ -122,6 +122,22 @@ class TestCP2KEngineAtoms(CP2KEngineTestCase):
             self.engine.atoms = ['Co', 'O']
 
 
+class TestCP2KEngineTemperature(CP2KEngineTestCase):
+    def test_atoms_getting(self):
+        """
+        Test that the correct temperature is returned
+        """
+        self.assertAlmostEqual(85, self.engine.temp)
+
+    def test_atoms_setting(self):
+        """
+        Test that temperature cannot be set
+        """
+        with self.assertRaises(AttributeError,
+                               msg="Temp should not be allowed assignment"):
+            self.engine.temp = 298
+
+
 class TestCP2KEnginePositions(CP2KEngineTestCase):
     def test_set_positions_wrong_num_atoms(self):
         """

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_inputs.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_inputs.py
@@ -69,7 +69,7 @@ class TestCP2KInputsPositions(CP2KInputsTestCase):
         """
         Compare expected positions to those actually stored by an engine
         :param expected: Array of expected positions
-        :param engine: Engine to compare to
+        :param inputs: engine to compare to
         """
         actual = inputs.cp2k_dict["+force_eval"][0]["+subsys"]["+coord"]["*"]
 
@@ -126,7 +126,7 @@ class TestCP2KInputsVelocities(CP2KInputsTestCase):
         Compare the expected values of a velocity to those actually stored by
         an engine
         :param expected: array of expected velocities
-        :param engine: engine to check if velocities match
+        :param inputs: engine to check if velocities match
         """
         # Internal Representation of stored positions for CP2K
         actual = inputs.cp2k_dict["+force_eval"][0]["+subsys"]["+velocity"]["*"]
@@ -203,5 +203,3 @@ class TestCP2KInputsTimeStep(CP2KInputsTestCase):
 
         self.assertEqual(traj["filename"], filename,
                          msg="Trajectory filename was not set correctly")
-
-

--- a/transition_sampling/tests/engine_tests/test_abstract_engine.py
+++ b/transition_sampling/tests/engine_tests/test_abstract_engine.py
@@ -45,6 +45,10 @@ class AbstractEngineMock(AbstractEngine):
     def atoms(self) -> Sequence[str]:
         return super().atoms
 
+    @property
+    def temp(self) -> float:
+        return super().temp
+
     def set_positions(self, positions: np.ndarray) -> None:
         super().set_positions(positions)
 


### PR DESCRIPTION
To sample from the boltzmann dist., we need the temperature of the system. This enforces that for all engines and implements it for CP2K.