### PR TITLE
Initialize aimless shooting from guesses and add state retries

### DIFF
--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -92,7 +92,10 @@ class AimlessShooting:
                         f"({n_state_tries*n_vel_tries}) total unsuccessful runs"
                         f" in a row")
 
-                self.current_start = random.choice(tuple(self.unique_states))
+                # Convert set to tuple so we can randomly choose, then convert
+                # the stored tuple back into an array
+                selected_tuple = random.choice(tuple(self.unique_states))
+                self.current_start = np.asarray(selected_tuple)
 
             else:
                 # Pick a new starting position based on the current offset
@@ -122,7 +125,10 @@ class AimlessShooting:
                                     f"state_{self.total_count}.xyz")
 
                 xyz.write_xyz_frame(path, self.engine.atoms, self.current_start)
-                self.unique_states.add(self.current_start)
+
+                # convert np array to tuples so its immutable and hashable
+                hashable_state = tuple(map(tuple, self.current_start))
+                self.unique_states.add(hashable_state)
 
                 # Update the total number of states we've generated
                 self.total_count += 1

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -83,9 +83,11 @@ class AimlessShooting:
         n_points
             Number of total points to generate
         n_state_tries
-            Number of retries to find another point before failing
+            Number of consecutive states to try resampling before failing 
+            completely
         n_vel_tries
-            Number of retries to find another point before failing
+            Number of times to try resampling velocities on a single state
+            before moving on to try a new state
         """
         accepted_states = 0
         states_since_success = 0

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -49,7 +49,7 @@ class AimlessShooting:
         The overall total count of states generated, including non-unique ones.
     """
     def __init__(self, engine: AbstractEngine, position_dir: str,
-                 results_dir: str, starting_xyz: str):
+                 results_dir: str):
         self.engine = engine
         self.position_dir = position_dir
         self.results_dir = results_dir

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -210,7 +210,7 @@ class AbstractEngine(ABC):
         Parameters
         ----------
         velocities : np.ndarray with shape (n, 3)
-            The positions for atoms to be set to.
+            The velocities for atoms to be set to.
 
         Raises
         -------

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -212,7 +212,11 @@ class CP2KEngine(AbstractEngine):
 
             # Append the error from stdout to the output file
             with open(output_file, "a") as f:
+                f.write("\nFAILURE \n")
+                f.write("STDOUT: \n")
                 f.write(stdout.decode('ascii'))
+                f.write("\nSTDERR: \n")
+                f.write(stderr.decode('ascii'))
 
             raise RuntimeError("Process failed")
 

--- a/transition_sampling/tests/algo_tests/test_aimless_shooting.py
+++ b/transition_sampling/tests/algo_tests/test_aimless_shooting.py
@@ -13,7 +13,7 @@ class NextPositionTest(unittest.TestCase):
         # Set the seed for reproducible results.
         np.random.seed(1)
 
-        aimless = AimlessShooting(None, None, None, None)
+        aimless = AimlessShooting(None, None, None)
         aimless.current_start = np.zeros((2, 3))
 
         fwd = {"commit": 1,


### PR DESCRIPTION
I believe this is the last step to make the aimless shooting part work minimally. The two major changes are 
- Given a directory of guesses for transition states, loop through them see if any are accepted. If they are, add them to a pool of unique accepted states.
- Retrying by going back to old states that have worked before. For a given state, we try resampling the velocity `n_vel_times` times to get it accepted. Previously if all of those failed to be accepted, the entire process failed. Now if this fails, we go back to a collection of accepted states that have worked before and randomly select one of those, repeating the velocity sampling with it. If this fails `n_state_tries` in a row, only then does the entire process fail.


Things that are still required:
- CP2K Inputs still needs everything defined in the `&COORDS` 