### PR TITLE
Keep track of all generated states, accepted or rejected

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cp2k-input-tools~=0.5.1
 cp2k-output-tools~=0.3.1
 numpy
+pandas

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -9,6 +9,7 @@ import random
 from typing import Sequence, Optional
 
 import numpy as np
+import pandas as pd
 
 import transition_sampling.util.xyz as xyz
 from transition_sampling.util.periodic_table import atomic_symbols_to_mass
@@ -28,7 +29,9 @@ class AimlessShooting:
     position_dir
         A directory containing only xyz positions of guesses at transition
         states. These positions will be used to try to kickstart the algorithm.
-    results_dir
+    results_xyz
+        A directory to store generated transition states.
+    results_csv
         A directory to store generated transition states.
 
     Attributes
@@ -37,7 +40,7 @@ class AimlessShooting:
         Engine used to run the simulations
     position_dir : str
         Directory containing xyz guesses of transition states.
-    results_dir : str
+    results_csv : str
         Directory where generated transition states will be stored.
     current_offset : int
         -1, 0 or +1. The delta-t offset the point being run with engine
@@ -48,10 +51,23 @@ class AimlessShooting:
         A list of the accepted positions. Contains duplicates.
     """
     def __init__(self, engine: AbstractEngine, position_dir: str,
-                 results_dir: str):
+                 results_xyz: str, results_csv: str = "aimless_shooting.csv"):
         self.engine = engine
         self.position_dir = position_dir
-        self.results_dir = results_dir
+        self.results_xyz = results_xyz
+        self.results_csv = results_csv
+
+        # Write the CSV header if doesn't exist, otherwise figure out what
+        # index we're writing to.
+        if not os.path.isfile(self.results_csv):
+            with open(self.results_csv, "w") as f:
+                f.write("index, forward_basin, reverse_basin, box_x, box_y, box_z\n")
+
+            self.cur_index = 0
+
+        else:
+            df = pd.read_csv(self.results_csv)
+            self.cur_index = df["index"].max() + 1
 
         self.current_offset = random.choice([-1, 0, 1])
         self.current_start = None
@@ -225,17 +241,19 @@ class AimlessShooting:
             vels = generate_velocities(self.engine.atoms, self.engine.temp)
             result = self._run_one_velocity(vels)
 
-            if result is not None and self.is_accepted(result):
-                # Break out of try loop, we found an accepted state
-                # Write the state and merge it into our set of uniques
-                path = os.path.join(self.results_dir,
-                                    f"state_{len(self.accepted_states)}.xyz")
+            if result is not None:
+                # Record all runs that did not end in an Exception
+                with open(self.results_xyz, "a") as xyz_file:
+                    xyz.write_xyz_frame(xyz_file, self.engine.atoms,
+                                        self.current_start)
 
-                xyz.write_xyz_frame(path, self.engine.atoms, self.current_start)
+                self.write_csv_line(result)
 
-                self.accepted_states.append(self.current_start)
-
-                return result
+                if self.is_accepted(result):
+                    # Break out of try loop, we found an accepted state
+                    # Record it in our list
+                    self.accepted_states.append(self.current_start)
+                    return result
 
         # Did not have an accepted state by changing velocity in n_attempts
         return None
@@ -316,6 +334,15 @@ class AimlessShooting:
         return result.fwd["commit"] is not None and \
             result.rev["commit"] is not None and \
             result.fwd["commit"] != result.rev["commit"]
+
+    def write_csv_line(self, result: ShootingResult):
+        columns = [self.cur_index, result.fwd["commit"], result.rev["commit"],
+                   self.engine.box_size[0], self.engine.box_size[1],
+                   self.engine.box_size[2]]
+
+        with open(self.results_csv, "a") as file:
+            file.write(", ".join([str(x) for x in columns]))
+            file.write("\n")
 
 
 def generate_velocities(atoms: Sequence[str], temp: float) -> np.array:

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -61,7 +61,8 @@ class AimlessShooting:
         # index we're writing to.
         if not os.path.isfile(self.results_csv):
             with open(self.results_csv, "w") as f:
-                f.write("index, forward_basin, reverse_basin, box_x, box_y, box_z\n")
+                f.write("index, accepted, forward_basin, reverse_basin, box_x,"
+                        " box_y, box_z\n")
 
             self.cur_index = 0
 
@@ -248,6 +249,7 @@ class AimlessShooting:
                                         self.current_start)
 
                 self.write_csv_line(result)
+                self.cur_index += 1
 
                 if self.is_accepted(result):
                     # Break out of try loop, we found an accepted state
@@ -336,7 +338,8 @@ class AimlessShooting:
             result.fwd["commit"] != result.rev["commit"]
 
     def write_csv_line(self, result: ShootingResult):
-        columns = [self.cur_index, result.fwd["commit"], result.rev["commit"],
+        columns = [self.cur_index, self.is_accepted(result),
+                   result.fwd["commit"], result.rev["commit"],
                    self.engine.box_size[0], self.engine.box_size[1],
                    self.engine.box_size[2]]
 

--- a/transition_sampling/engines/cp2k/CP2K_inputs.py
+++ b/transition_sampling/engines/cp2k/CP2K_inputs.py
@@ -46,7 +46,7 @@ class CP2KInputsHandler:
         if self._atoms is None:
             # TODO: How does this handle coordinates linked in a separate file?
             # Return the first two places for each coordinate entry
-            self._atoms = [entry[0:2] for entry in self._get_coord()]
+            self._atoms = [entry[0:2].strip() for entry in self._get_coord()]
 
         return self._atoms
 

--- a/transition_sampling/util/xyz.py
+++ b/transition_sampling/util/xyz.py
@@ -38,15 +38,14 @@ def read_xyz_frame(ifile: typing.IO) -> typing.Union[tuple[None, bool],
     return xyz, eof
 
 
-def write_xyz_frame(file_name: str, atoms: typing.Sequence[str],
+def write_xyz_frame(file: typing.IO, atoms: typing.Sequence[str],
                     frame: np.ndarray) -> None:
-    """Write a single xyz frame to a new file.
-
+    """Write a single xyz frame to the given file.
 
     Parameters
     ----------
-    file_name
-        Name of the file to write to
+    file
+        Open file for writing to
     atoms
         list of atom names
     frame
@@ -63,13 +62,11 @@ def write_xyz_frame(file_name: str, atoms: typing.Sequence[str],
         raise ValueError(f"Number of atoms ({len(atoms)}) did not match"
                          f" the number of coordinates ({frame.shape[0]})")
 
-    with open(file_name, "w") as file:
+    file.write(f"{len(atoms)}\n\n")
 
-        file.write(f"{len(atoms)}\n\n")
+    for i in range(len(atoms)):
+        file.write(f"{atoms[i]} ")
 
-        for i in range(len(atoms)):
-            file.write(f"{atoms[i]} ")
-
-            file.write(' '.join([str(x) for x in frame[i, :]]))
-            file.write("\n")
+        file.write(' '.join([str(x) for x in frame[i, :]]))
+        file.write("\n")
 

--- a/transition_sampling/util/xyz.py
+++ b/transition_sampling/util/xyz.py
@@ -39,7 +39,7 @@ def read_xyz_frame(ifile: typing.IO) -> typing.Union[tuple[None, bool],
 
 
 def write_xyz_frame(file: typing.IO, atoms: typing.Sequence[str],
-                    frame: np.ndarray) -> None:
+                    frame: np.ndarray, comment: str = "") -> None:
     """Write a single xyz frame to the given file.
 
     Parameters
@@ -50,6 +50,8 @@ def write_xyz_frame(file: typing.IO, atoms: typing.Sequence[str],
         list of atom names
     frame
         array with shape (n_atoms, 3)
+    comment
+        string to be placed in the comment line. Defaults to empty.
 
     Raises
     ------
@@ -62,11 +64,11 @@ def write_xyz_frame(file: typing.IO, atoms: typing.Sequence[str],
         raise ValueError(f"Number of atoms ({len(atoms)}) did not match"
                          f" the number of coordinates ({frame.shape[0]})")
 
-    file.write(f"{len(atoms)}\n\n")
+    file.write(f"{len(atoms)}\n")
+    file.write(f"{comment}\n")
 
     for i in range(len(atoms)):
         file.write(f"{atoms[i]} ")
 
         file.write(' '.join([str(x) for x in frame[i, :]]))
         file.write("\n")
-


### PR DESCRIPTION
Previously we were only recording accepted transition states. This change records all states generated, accepted or rejected, in `results_xyz` as a single xyz frame. It is accompanied by a `results_csv` file that tracks metadata about each state. It specifically has the format (with the type in `<>`:
```
index <int>, accepted <bool>, forward_basin <int>, reverse_basin <int>, box_x <float>, box_y <float>, box_z <float>
```
This allows us to calculate statistics for both what makes a transition state and what does not. These files will be created if they do not exist, otherwise they will be appended to, allowing for multiple runs of the same system while only maintaining two files.

Both files are required for the likelihood maximization later on. Right now, the forward and reverse committed basins are both recorded in the comment line of the xyz in case the csv is lost.

Right now there aren't any tests for this, I've been waiting until we have a solid interface down and it seems like this may be it. Tested manually on mox with SN2 PM6 system. 