### PR TITLE
Mutiple Reactant/Product Basins

### DIFF
--- a/transition_sampling/algo/__init__.py
+++ b/transition_sampling/algo/__init__.py
@@ -1,1 +1,2 @@
 from .aimless_shooting import AimlessShooting
+from .acceptors import DefaultAcceptor, MultiBasinAcceptor

--- a/transition_sampling/algo/acceptors.py
+++ b/transition_sampling/algo/acceptors.py
@@ -6,6 +6,9 @@ from transition_sampling.engines import ShootingResult
 
 
 class AbstractAcceptor(ABC):
+    """Abstract class that defines what shooting points should be accepted
+
+    """
     @abstractmethod
     def is_accepted(self, result: ShootingResult) -> bool:
         """Determines if a ShootingResult should be accepted or rejected
@@ -40,14 +43,38 @@ class MultiBasinAcceptor(AbstractAcceptor):
 
     Parameters
     ----------
-    reactants:
+    reactants
         Set of basins to be considered as reactants, as defined in the plumed
         input
-    products:
+    products
         Set of basins to be considered as products, as defined in the plumed
-         input
+        input
+
+    Attributes
+    ----------
+    reactants
+        Set of basins to be considered as reactants, as defined in the plumed
+        input
+    products
+        Set of basins to be considered as products, as defined in the plumed
+        input
+
+    Raises
+    ------
+    ValueError
+        If the intersection of reactants and products is not empty, i.e. there
+        is a basin shared by both.
     """
     def __init__(self, reactants: set[int], products: set[int]):
+        if len(reactants) < 1:
+            raise ValueError("Reactants must have at least one entry.")
+
+        if len(products) < 1:
+            raise ValueError("Products must have at least one entry.")
+
+        if len(reactants.intersection(products)) != 0:
+            raise ValueError("Reactants and products cannot contain the same "
+                             f"basin(s): {reactants.intersection(products)}")
         self.reactants = reactants
         self.products = products
 

--- a/transition_sampling/algo/acceptors.py
+++ b/transition_sampling/algo/acceptors.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from transition_sampling.engines import ShootingResult
+
+
+class AbstractAcceptor(ABC):
+    @abstractmethod
+    def is_accepted(self, result: ShootingResult) -> bool:
+        """Determines if a ShootingResult should be accepted or rejected
+
+        Parameters
+        ----------
+        result
+            The ShootingResult to be tested
+
+        Returns
+        -------
+        True if it should be accepted, False otherwise.
+        """
+        pass
+
+
+class DefaultAcceptor(AbstractAcceptor):
+    """Accepts as long as both trajectories committed to different basins"""
+    def is_accepted(self, result: ShootingResult) -> bool:
+        fwd = result.fwd["commit"]
+        rev = result.rev["commit"]
+
+        return fwd is not None and rev is not None and fwd != rev
+
+
+class MultiBasinAcceptor(AbstractAcceptor):
+    """Acceptor with basins split into reactants and products.
+
+    To be accepted, both trajectories must have committed and must commit to
+    a different basin type, e.g. one to reactants and one to products, but not
+    both to products.
+
+    Parameters
+    ----------
+    reactants:
+        Set of basins to be considered as reactants, as defined in the plumed
+        input
+    products:
+        Set of basins to be considered as products, as defined in the plumed
+         input
+    """
+    def __init__(self, reactants: set[int], products: set[int]):
+        self.reactants = reactants
+        self.products = products
+
+    def is_accepted(self, result: ShootingResult) -> bool:
+        fwd = result.fwd["commit"]
+        rev = result.rev["commit"]
+
+        if fwd is None or rev is None:
+            return False
+
+        return (fwd in self.reactants and rev in self.products) or \
+               (fwd in self.products and rev in self.reactants)

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -38,6 +38,11 @@ class AimlessShooting:
         such as forward and reverse committed basins. Both files are necessary
         for likelihood maximization. Appended to if it already exists, otherwise
         it is created.
+    acceptor:
+        An acceptor that implements an `is_accepted` method to determine if a
+        shooting point should be considered accepted or not. If None, the
+        DefaultAcceptor is used, which accepts if both trajectories commit to
+        different basins.
 
     Attributes
     ----------
@@ -56,6 +61,9 @@ class AimlessShooting:
         xyz array of the current starting position. Has shape (num_atoms, 3)
     accepted_states : list[np.ndarray]
         A list of the accepted positions. Contains duplicates.
+    acceptor:
+        An acceptor that implements an `is_accepted` method to determine if a
+        shooting point should be considered accepted or not.
     """
     def __init__(self, engine: AbstractEngine, position_dir: str,
                  results_xyz: str, results_csv: str,

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -10,6 +10,7 @@ from typing import Sequence, Optional
 import numpy as np
 import pandas as pd
 
+from .acceptors import AbstractAcceptor, DefaultAcceptor
 import transition_sampling.util.xyz as xyz
 from transition_sampling.util.periodic_table import atomic_symbols_to_mass
 from transition_sampling.engines import AbstractEngine, ShootingResult
@@ -57,11 +58,16 @@ class AimlessShooting:
         A list of the accepted positions. Contains duplicates.
     """
     def __init__(self, engine: AbstractEngine, position_dir: str,
-                 results_xyz: str, results_csv: str = "aimless_shooting.csv"):
+                 results_xyz: str, results_csv: str,
+                 acceptor: AbstractAcceptor = None):
         self.engine = engine
         self.position_dir = position_dir
         self.results_xyz = results_xyz
         self.results_csv = results_csv
+        self.acceptor = acceptor
+
+        if self.acceptor is None:
+            self.acceptor = DefaultAcceptor()
 
         # Write the CSV header if doesn't exist, otherwise figure out what
         # index we're writing to.
@@ -268,7 +274,7 @@ class AimlessShooting:
                 self.write_csv_line(result)
                 self.cur_index += 1
 
-                if self.is_accepted(result):
+                if self.acceptor.is_accepted(result):
                     # Break out of try loop, we found an accepted state
                     # Record it in our list
                     self.accepted_states.append(self.current_start)
@@ -336,23 +342,6 @@ class AimlessShooting:
         chosen_index = np.random.choice(indices)
 
         return concat_frames[chosen_index, :, :]
-
-    @staticmethod
-    def is_accepted(result: ShootingResult) -> bool:
-        """Determines if a ShootingResult should be accepted or rejected
-
-        Parameters
-        ----------
-        result
-            The ShootingResult to be tested
-
-        Returns
-        -------
-        True if it should be accepted, False otherwise.
-        """
-        return result.fwd["commit"] is not None and \
-            result.rev["commit"] is not None and \
-            result.fwd["commit"] != result.rev["commit"]
 
     def write_csv_line(self, result: ShootingResult) -> None:
         """Write a single line to the results_csv for the given result.

--- a/transition_sampling/tests/algo_tests/test_acceptors.py
+++ b/transition_sampling/tests/algo_tests/test_acceptors.py
@@ -1,0 +1,94 @@
+import unittest
+
+from transition_sampling.engines import ShootingResult
+from transition_sampling.algo import DefaultAcceptor, MultiBasinAcceptor
+from transition_sampling.algo.acceptors import AbstractAcceptor
+
+
+class TestDefaultAcceptor(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.acceptor = DefaultAcceptor()
+
+    def test_no_commit_cases(self):
+        """Test cases where there are no commits"""
+        self.assertFalse(_fwd_is_none(self.acceptor),
+                         msg="No fwd commit should not be accepted")
+        self.assertFalse(_rev_is_none(self.acceptor),
+                         msg="No rev commit should not be accepted")
+        self.assertFalse(_both_are_none(self.acceptor),
+                         msg="Both not committing should not be accepted")
+
+    def test_both_same(self):
+        """Test case where fwd and rev commit to same basin"""
+        point = ShootingResult({"commit": 1}, {"commit": 1})
+        self.assertFalse(self.acceptor.is_accepted(point),
+                         msg="Both not committing to same should not be accepted")
+
+    def test_both_different(self):
+        """Test case where fwd and rev commit to different basins"""
+        point = ShootingResult({"commit": 1}, {"commit": 2})
+        self.assertTrue(self.acceptor.is_accepted(point),
+                        msg="Both not committing to same should be accepted")
+
+
+class TestMultiBasinAcceptor(TestDefaultAcceptor):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        reactants = {1, 2}
+        products = {3, 4}
+        self.acceptor = MultiBasinAcceptor(reactants, products)
+
+    def test_both_different(self):
+        """Test multiple cases where fwd and rev commit to different basins"""
+        point = ShootingResult({"commit": 1}, {"commit": 2})
+        self.assertFalse(self.acceptor.is_accepted(point),
+                        msg="Both committing to reactants should not be accepted")
+
+        point = ShootingResult({"commit": 3}, {"commit": 4})
+        self.assertFalse(self.acceptor.is_accepted(point),
+                         msg="Both committing to products should not be accepted")
+
+        point = ShootingResult({"commit": 1}, {"commit": 4})
+        self.assertTrue(self.acceptor.is_accepted(point),
+                         msg="Committing to reactants and products should be accepted")
+
+        point = ShootingResult({"commit": 3}, {"commit": 2})
+        self.assertTrue(self.acceptor.is_accepted(point),
+                        msg="Committing to reactants and products should be accepted")
+
+    def test_overlapping_reactants_products(self):
+        """Test when reactants and products share a basin"""
+        reactants = {1, 2}
+        products = {2, 3, 4}
+        with self.assertRaises(ValueError, msg="Overlapping basins should fail"):
+            MultiBasinAcceptor(reactants, products)
+
+    def test_empty_reactants_products(self):
+        """Test when reactants or products are empty"""
+        reactants = set()
+        products = {2, 3, 4}
+        with self.assertRaises(ValueError, msg="Empty reactants should fail"):
+            MultiBasinAcceptor(reactants, products)
+
+        reactants = set()
+        products = {2, 3, 4}
+        with self.assertRaises(ValueError, msg="Empty products should fail"):
+            MultiBasinAcceptor(products, reactants)
+
+
+def _fwd_is_none(acceptor: AbstractAcceptor) -> bool:
+    point = ShootingResult({"commit": None}, {"commit": 1})
+    return acceptor.is_accepted(point)
+
+
+def _rev_is_none(acceptor: AbstractAcceptor) -> bool:
+    point = ShootingResult({"commit": 1}, {"commit": None})
+    return acceptor.is_accepted(point)
+
+
+def _both_are_none(acceptor: AbstractAcceptor) -> bool:
+    point = ShootingResult({"commit": None}, {"commit": None})
+    return acceptor.is_accepted(point)

--- a/transition_sampling/tests/algo_tests/test_aimless_shooting.py
+++ b/transition_sampling/tests/algo_tests/test_aimless_shooting.py
@@ -5,6 +5,8 @@ from transition_sampling.algo import AimlessShooting
 from transition_sampling.algo.aimless_shooting import generate_velocities
 import numpy as np
 
+import tempfile
+
 
 class NextPositionTest(unittest.TestCase):
     """Test that picking the next position works"""
@@ -14,24 +16,26 @@ class NextPositionTest(unittest.TestCase):
         # Set the seed for reproducible results.
         np.random.seed(1)
 
-        aimless = AimlessShooting(None, None, None)
-        aimless.current_start = np.zeros((2, 3))
+        with tempfile.TemporaryDirectory() as temp_dir:
 
-        fwd = {"commit": 1,
-               "frames": np.array([np.zeros((2, 3)) + 1, np.zeros((2, 3)) + 2])}
+            aimless = AimlessShooting(None, None, None, f"{temp_dir}/csv.csv")
+            aimless.current_start = np.zeros((2, 3))
 
-        rev = {"commit": 2,
-               "frames": np.array([np.zeros((2, 3)) - 1, np.zeros((2, 3)) - 2])}
+            fwd = {"commit": 1,
+                   "frames": np.array([np.zeros((2, 3)) + 1, np.zeros((2, 3)) + 2])}
 
-        test_result = ShootingResult(fwd, rev)
+            rev = {"commit": 2,
+                   "frames": np.array([np.zeros((2, 3)) - 1, np.zeros((2, 3)) - 2])}
 
-        correct_choice = [1, -1, -2, 1, 0, -2, 0, 0, -2, 1]
+            test_result = ShootingResult(fwd, rev)
 
-        for i in range(0, 10):
-            aimless.current_offset = (i % 3) - 1
+            correct_choice = [1, -1, -2, 1, 0, -2, 0, 0, -2, 1]
 
-            picked = aimless.pick_starting(test_result)
-            self.assertEqual(correct_choice[i], picked[0, 0])
+            for i in range(0, 10):
+                aimless.current_offset = (i % 3) - 1
+
+                picked = aimless.pick_starting(test_result)
+                self.assertEqual(correct_choice[i], picked[0, 0])
 
 
 class VelocityGenerationTest(unittest.TestCase):


### PR DESCRIPTION
This implements a way to have multiple product or reactant basins to determine accepting conditions. We do this by refactoring the "accept" method into an object that gets passed to the aimless shooting class. This allows us to have multiple versions of accepting conditions by creating different classes, so long as they implement the method described in `AbstractAcceptor`. Furthermore, this allows us to test these conditions independently from the aimless shooting algorithm.

Right now there are two acceptors:
- `DefaultAcceptor` - same behavior as before, accepts if both tajectories commit to different basins
- `MultiBasinAcceptor` - takes a reactants and products set of basins and only accepts if both trajectories commit to one from each. 

Finally, removes the `csv` being generated in the algo tests by redirecting to a temporary file.