### PR TITLE
Single likelihood maximization calculation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cp2k-input-tools~=0.5.1
 cp2k-output-tools~=0.3.1
 numpy
 pandas
+scipy

--- a/transition_sampling/algo/likelihood.py
+++ b/transition_sampling/algo/likelihood.py
@@ -1,169 +1,238 @@
-import typing
+"""
+Likelihood maximization to determine reaction coordinates from aimless shooting
+results.
+
+In all documentation below, *n* refers to the number of shooting points being
+used as data and *m* refers to the number of collective variables contributing
+to the reaction coordinate.
+"""
+from __future__ import annotations
 
 from scipy.optimize import basinhopping
-import pandas as pd
 import numpy as np
 
 
-def calc_r(alphas: np.ndarray, colvars: np.ndarray) -> np.ndarray:
+def optimize(colvars, is_accepted, niter=100) -> np.ndarray:
     """
-    Calculate linear combination reaction coordinates given a weights vector and colvars matrix
+    Use basinhopping for global optimization of rxn coords as a linear
+    combination of CVs.
+
+    The reaction coordinate :math:`r` is linear combination of :math:`m`
+    collective variables :math:`\\mathbf{x}` with weights :math:`\\mathbf{\\alpha}`
+    plus a constant :math:`\\alpha_0`:
+
+    .. math ::
+        r(\\mathbf{x}) = \\alpha_0 + \\sum_{i=1}^m \\alpha_ix_i
+
+    The probability that a shooting point is on a transition path (TP) is chosen
+    to be modeled as a non-gaussian bell curve and is given by:
+
+    .. math ::
+        \\Pr(TP|\\mathbf{x}) = p_0 (1 - \\tanh^2(r(\\mathbf{x}))
+
+    This probability is maximized for CVs of accepted shooting points and
+    minimized for rejected shooting points by optimizing
+    :math:`\\mathbf{\\alpha}`, :math:`\\alpha_0`, and :math:`p_0`.
 
     Parameters
     ----------
-    alphas:
+    colvars
+        An (n x m) matrix where n is the number of shooting points and m is the
+        number of collective variables to include in the reaction
+    is_accepted
+        A length n array of booleans indicating if the ith state was accepted
+        or not.
+    niter
+        Number of local optimizations to perform with basinhopping. Linearly
+        scales.
+
+    Returns
+    -------
+        Array of length (m+2) of optimized parameters as [p0, alpha0, alphas]
+
+    Raises
+    ------
+    RuntimeWarning
+        If the optimization was not successful
+    """
+    n_parameters = colvars.shape[1] + 2
+    # Create bounds for p_0 to be between 0 and 1, all other parameters are
+    # unbounded.
+    bnds = [(0, 1) if i == 0 else (None, None) for i in range(n_parameters)]
+
+    # start with a random guess, all between 0 and 1. Doesn't actually matter
+    # because basin hopping will make its own after one iteration.
+    x0 = np.random.random_sample(n_parameters)
+
+    # Setting jac = True indicates that the objective function also returns
+    # the jacobian
+    min_args = {"args": (colvars, is_accepted), "bounds": bnds, "jac": True}
+
+    sol = basinhopping(obj_func, x0, niter=niter, minimizer_kwargs=min_args)
+
+    if not sol.success:
+        raise RuntimeWarning(f"Solution did not converge {sol}")
+
+    return sol.x
+
+
+# Let n refer to the number of shooting points and m refer to the number of CVs
+
+def calc_r(alphas: np.ndarray,
+           colvars: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate linear combination of reaction coordinates given a weights vector
+    and colvars matrix. Also returns the jacobian with respect to the alphas.
+
+    Parameters
+    ----------
+    alphas
         a length m+1 array where m is the number of collective variables being
         analyzed. alphas[0] refers to the constant added term.
 
-    colvars:
-        an (n x m) matrix where n is the number of transition states and m is
+    colvars
+        an (n x m) matrix where n is the number of shooting points and m is
         the number of collective variables.
 
     Returns
     -------
-    A length n vector of calculated reaction coordinates, one for each transition state.
+    A tuple of two numpy arrays.
+    First term:
+        A length n vector of calculated reaction coordinates, one for each
+        shooting point.
+    Second term:
+        An (n x m + 2) matrix representing the jacobian of each coordinate with
+        respect to each alpha. The 0 index column is empty space allocated for
+        p_0 later on. Columns 1:m+2 represent jacobians of the alphas
     """
-    return alphas[0] + np.matmul(colvars, alphas[1:])
+    r_vals = alphas[0] + np.matmul(colvars, alphas[1:])
+
+    # First column is d/dp_0 (all zeros for this function)
+    r_jacobian = np.zeros((colvars.shape[0], alphas.size + 1))
+    # second column is d/dalpha_0 (all ones since constant)
+    r_jacobian[:, 1] = 1
+    # rest is just the d/dalphas, which are just the respective colvars since
+    # the alphas are the coefficients
+    r_jacobian[:, 2:] = colvars
+    return r_vals, r_jacobian
 
 
-def calc_r_jacobian(alphas: np.ndarray, colvars: np.ndarray) -> np.ndarray:
-    # returns an (n states x m_parameters)
-    # First column is p_0 (all zeros for this function)
-    # second column is alpha_0 (all ones)
-    # rest is just the nultiplied alphas, which are just the colvars since
-    # they are the coffecients
-
-    result = np.zeros((colvars.shape[0], alphas.size + 1))
-    result[:, 1] = 1
-    result[:, 2:] = colvars
-    return result
-
-
-def calc_p(p_0: float, r_vals: np.ndarray) -> np.ndarray:
+def calc_p(p_0: float, r_vals: np.ndarray,
+           r_jac: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """
-    Calculate P(TP|r) for reaction coordinate given a weights vector and colvars
+    Calculate P(TP|r) for reaction coordinate given a weights vector and
+    colvars. Also returns the jacobian.
 
     Parameters
     ----------
-    p_0:
-        Constant multipler
+    p_0
+        Constant multiplier
 
-    r_vals:
+    r_vals
         A length n vector of calculated reaction coordinates.
+
+    r_jac
+        An (n x m + 2) matrix representing the jacobian of each r with respect
+        to each alpha. The 0 index column should be empty space. Columns 1:m+2
+        represent jacobians of the alphas
 
     Returns
     -------
-    A length n vector of P(TP|r) for every r
+    A tuple of two numpy arrays.
+    First term:
+        A length n vector of P(TP|r) for every r
+    Second term:
+        An (n x m + 2) matrix representing the jacobian of each p with respect
+        to all parameters. The columns are ordered as p_0, alphas.
     """
     lower_threshold = 1.0e-15
     upper_threshold = 1.0 - lower_threshold
 
-    f = p_0 * (1 - np.power(np.tanh(r_vals), 2))
+    p_vals = p_0 * (1 - np.power(np.tanh(r_vals), 2))
 
-    if np.any(f < lower_threshold):
-        f = np.where(f < lower_threshold, lower_threshold, f)
+    # make sure the values don't get rounded to 0 or 1, which is the asymptotic
+    # limit of these functions.
+    if np.any(p_vals < lower_threshold):
+        p_vals = np.where(p_vals < lower_threshold, lower_threshold, p_vals)
 
-    if np.any(f > upper_threshold):
-        f = np.where(f > upper_threshold, upper_threshold, f)
+    if np.any(p_vals > upper_threshold):
+        p_vals = np.where(p_vals > upper_threshold, upper_threshold, p_vals)
 
-    return f
+    # d/dr are all on diagonal since no r values affect one another here. This
+    # is a single vector representing a diagonal (n x n) matrix, all off
+    # off diagonals are 0.
+    diag_vector = -2 * p_0 * np.tanh(r_vals) * np.power(np.cosh(r_vals), -2)
 
+    # Multiply by the r jacobian to get an (n x m+2) jacobian. This takes
+    # advantage of the diagonal to achieve a 1000x+ speedup as opposed to
+    # performing a full (n x n) x (n x m+2) matrix multiplication
 
-def calc_p_jacobian(p_0: float, r_vals: np.ndarray, r_vals_jac) -> np.ndarray:
-    # Returns an (n x n) matrix
+    # - diag_vector.reshape(-1, 1) casts the vector to a (n, 1) shape to allow
+    # broadcasting
+    # - this is broadcasted to (n x m+2) by concatenating the column m+2 times
+    # - finally, this is elementwise multiplied to the r_jac (n x m+2). This
+    # equivalent to the full matrix multiplication.
+    p_jacobian = np.multiply(diag_vector.reshape(-1, 1), r_jac)
 
-    # d/dr are all on diagonal since no r values affect one another here
-    diag = np.diag(-2 * p_0 * np.tanh(r_vals) * np.power(np.cosh(r_vals), -2))
+    # update the first column, previously all 0s, because this is where p_0
+    # comes into play. p_0 is the coefficient in front of these terms.
+    p_jacobian[:, 0] = 1 - np.power(np.tanh(r_vals), 2)
 
-    # multiply by the r jacobian to get an (n x m_parameters)
-    result = np.matmul(diag, r_vals_jac)
-
-    # update the first column, previously all 0s, because this is where p0 comes
-    # into play
-    result[:, 0] = 1 - np.power(np.tanh(r_vals), 2)
-    return result
-
-
-def calc_obj_jacobian(to_opt: np.ndarray, colvars: np.ndarray,
-                      is_accepted: typing.Sequence[bool]) -> np.ndarray:
-    # Returns a (1 x m_parameters) matrix where m_parameters = len(to_opt)
-
-    r_jac = calc_r_jacobian(to_opt[1:], colvars)
-    r_vals = calc_r(to_opt[1:], colvars)
-    p_jac = calc_p_jacobian(to_opt[0], r_vals, r_jac)
-    p_vals = calc_p(to_opt[0], calc_r(to_opt[1:], colvars))
-
-    # this is (1 x n)
-    jac = np.ones(colvars.shape[0])
-
-    # derivatives of log of each p_val
-    jac[is_accepted] = 1 / p_vals[is_accepted]
-    jac[~is_accepted] = -1 / (1 - p_vals[~is_accepted])
-
-    # -1 because of the optimization
-    jac *= -1
-
-    return np.matmul(jac, p_jac)
+    return p_vals, p_jacobian
 
 
-def obj(to_opt: np.ndarray, colvars: np.ndarray,
-        is_accepted: typing.Sequence[bool]) -> float:
-    """
-    Objective function to minimize for colvar maximization
-
-    Parameters
-    ----------
-    to_opt:
-        Array of parameters to optimze. Convention is
-        - to_opt[0] : p_0 term
-        - to_opt[1] : alpha_0, i.e. the constant added weight
-        - to_opt[2:] : alphas_1...alphas_m for m collective variables.
-
-    colvars:
-        an (n x m) matrix where n is the number of transition states and
-        m is the number of collective variables.
-
-    is_accepted:
-        A length n boolean sequence corresponding to if the ith
-        state in colvars was accepted
-
-    Returns
-    -------
-    A value to be *minimized* for likelihood maximization
-    """
-    p_0 = to_opt[0]
-    return fixed_p0_obj(to_opt[1:], p_0, colvars, is_accepted)
-
-
-def fixed_p0_obj(to_opt: np.ndarray, p_0: float, colvars: np.ndarray,
-                 is_accepted: typing.Sequence[bool]) -> float:
+def obj_func(to_opt: np.ndarray, colvars: np.ndarray,
+             is_accepted: np.ndarray) -> tuple[float, np.ndarray]:
     """
     Objective function to minimize for colvar maximization with fixed p_0
 
     Parameters
     ----------
     to_opt:
-        Array of parameters to optimze. Convention is
-        - to_opt[0] : alpha_0, i.e. the constant added weight
-        - to_opt[1:] : alphas_1...alphas_m for m collective variables.
-
-    p_0:
-        A fixed p_0
+        Array of m+2 parameters to optimize. Convention is
+        - to_opt[0] : p_0 term
+        - to_opt[1] : alpha_0, i.e. the constant added weight
+        - to_opt[2:] : alphas_1...alphas_m for m collective variables.
 
     colvars:
-        an (n x m) matrix where n is the number of transition states and
-        m is the number of collective variables.
+        an (n x m) matrix where n is the number of shooting points and m is
+        the number of collective variables.
 
     is_accepted:
-        A length n boolean sequence corresponding to if the ith
-        state in colvars was accepted
+        A length n boolean np array corresponding to if the ith state in colvars
+        was accepted
 
     Returns
     -------
-    A value to be *minimized* for likelihood maximization
+    A tuple of float, numpy array.
+    First term:
+        The value to be *minimized* for likelihood maximization.
+    Second term:
+        m+2 length array representing the jacobian of the objective function for
+        each optimized parameter
     """
-    p_vals = calc_p(p_0, calc_r(to_opt, colvars))
+    p_0 = to_opt[0]
+    alphas = to_opt[1:]
+    r_vals, r_jac = calc_r(alphas, colvars)
+    p_vals, p_jac = calc_p(p_0, r_vals, r_jac)
+
+    p_accepted = p_vals[is_accepted]
+    p_rejected = 1 - p_vals[~is_accepted]
 
     # -1 for minimization
-    return -1 * (np.sum(np.log(p_vals[is_accepted])) + np.sum(
-        np.log(1 - p_vals[~is_accepted])))
+    obj_val = -1 * (np.sum(np.log(p_accepted)) + np.sum(np.log(p_rejected)))
+
+    # this is (1 x n)
+    jac = np.ones(colvars.shape[0])
+
+    # derivatives of log of each p_val
+    jac[is_accepted] = 1 / p_accepted
+    jac[~is_accepted] = -1 / p_rejected
+
+    # -1 because of the optimization
+    jac *= -1
+
+    # (1 x n) x (n x m + 2) to get a (1 x m + 2) jacobian
+    obj_jacobian = np.matmul(jac, p_jac)
+
+    return obj_val, obj_jacobian

--- a/transition_sampling/algo/likelihood.py
+++ b/transition_sampling/algo/likelihood.py
@@ -1,0 +1,119 @@
+import typing
+
+from scipy.optimize import basinhopping
+import pandas as pd
+import numpy as np
+
+
+def calc_r(alphas: np.ndarray, colvars: np.ndarray) -> np.ndarray:
+    """
+    Calculate linear combination reaction coordinates given a weights vector and colvars matrix
+
+    Parameters
+    ----------
+    alphas:
+        a length m+1 array where m is the number of collective variables being
+        analyzed. alphas[0] refers to the constant added term.
+
+    colvars:
+        an (n x m) matrix where n is the number of transition states and m is
+        the number of collective variables.
+
+    Returns
+    -------
+    A length n vector of calculated reaction coordinates, one for each transition state.
+    """
+    return alphas[0] + np.matmul(colvars, alphas[1:])
+
+
+def calc_p(p_0: float, r_vals: np.ndarray) -> np.ndarray:
+    """
+    Calculate P(TP|r) for reaction coordinate given a weights vector and colvars
+
+    Parameters
+    ----------
+    p_0:
+        Constant multipler
+
+    r_vals:
+        A length n vector of calculated reaction coordinates.
+
+    Returns
+    -------
+    A length n vector of P(TP|r) for every r
+    """
+    lower_threshold = 1.0e-15
+    upper_threshold = 1.0 - lower_threshold
+
+    f = p_0 * (1 - np.power(np.tanh(r_vals), 2))
+
+    if np.any(f < lower_threshold):
+        f = np.where(f < lower_threshold, lower_threshold, f)
+
+    if np.any(f > upper_threshold):
+        f = np.where(f > upper_threshold, upper_threshold, f)
+
+    return f
+
+
+def obj(to_opt: np.ndarray, colvars: np.ndarray,
+        is_accepted: typing.Sequence[bool]) -> float:
+    """
+    Objective function to minimize for colvar maximization
+
+    Parameters
+    ----------
+    to_opt:
+        Array of parameters to optimze. Convention is
+        - to_opt[0] : p_0 term
+        - to_opt[1] : alpha_0, i.e. the constant added weight
+        - to_opt[2:] : alphas_1...alphas_m for m collective variables.
+
+    colvars:
+        an (n x m) matrix where n is the number of transition states and
+        m is the number of collective variables.
+
+    is_accepted:
+        A length n boolean sequence corresponding to if the ith
+        state in colvars was accepted
+
+    Returns
+    -------
+    A value to be *minimized* for likelihood maximization
+    """
+    p_0 = to_opt[0]
+    return fixed_p0_obj(to_opt[1:], p_0, colvars, is_accepted)
+
+
+def fixed_p0_obj(to_opt: np.ndarray, p_0: float, colvars: np.ndarray,
+                 is_accepted: typing.Sequence[bool]) -> float:
+    """
+    Objective function to minimize for colvar maximization with fixed p_0
+
+    Parameters
+    ----------
+    to_opt:
+        Array of parameters to optimze. Convention is
+        - to_opt[0] : alpha_0, i.e. the constant added weight
+        - to_opt[1:] : alphas_1...alphas_m for m collective variables.
+
+    p_0:
+        A fixed p_0
+
+    colvars:
+        an (n x m) matrix where n is the number of transition states and
+        m is the number of collective variables.
+
+    is_accepted:
+        A length n boolean sequence corresponding to if the ith
+        state in colvars was accepted
+
+    Returns
+    -------
+    A value to be *minimized* for likelihood maximization
+    """
+    p_vals = calc_p(p_0, calc_r(to_opt, colvars))
+
+    # -1 for minimization
+    return -1 * (np.sum(np.log(p_vals[is_accepted])) + np.sum(
+        np.log(1 - p_vals[~is_accepted])))

--- a/transition_sampling/likelihood/optimization.py
+++ b/transition_sampling/likelihood/optimization.py
@@ -47,7 +47,6 @@ def optimize(colvars, is_accepted, niter=100, use_jac=True) -> np.ndarray:
     niter
         Number of local optimizations to perform with basinhopping. Linearly
         scales.
-
     use_jac
         True if the analytical jacobian should be used during gradient descent.
         Otherwise, the default finite difference approximation will be used.
@@ -97,11 +96,9 @@ def calc_r(alphas: np.ndarray, colvars: np.ndarray,
     alphas
         a length m+1 array where m is the number of collective variables being
         analyzed. alphas[0] refers to the constant added term.
-
     colvars
         an (n x m) matrix where n is the number of shooting points and m is
         the number of collective variables.
-
     calc_jac
         True if the jacobian should be calculated and returned.
 
@@ -119,13 +116,15 @@ def calc_r(alphas: np.ndarray, colvars: np.ndarray,
     """
     r_vals = alphas[0] + np.matmul(colvars, alphas[1:])
 
-    # First column is d/dp_0 (all zeros for this function)
-    r_jacobian = np.zeros((colvars.shape[0], alphas.size + 1))
-    # second column is d/dalpha_0 (all ones since constant)
-    r_jacobian[:, 1] = 1
-    # rest is just the d/dalphas, which are just the respective colvars
-    # since the alphas are the coefficients
-    r_jacobian[:, 2:] = colvars
+    r_jacobian = None
+    if calc_jac:
+        # First column is d/dp_0 (all zeros for this function)
+        r_jacobian = np.zeros((colvars.shape[0], alphas.size + 1))
+        # second column is d/dalpha_0 (all ones since constant)
+        r_jacobian[:, 1] = 1
+        # rest is just the d/dalphas, which are just the respective colvars
+        # since the alphas are the coefficients
+        r_jacobian[:, 2:] = colvars
 
     return r_vals, r_jacobian
 
@@ -140,10 +139,8 @@ def calc_p(p_0: float, r_vals: np.ndarray,
     ----------
     p_0
         Constant multiplier
-
     r_vals
         A length n vector of calculated reaction coordinates.
-
     r_jac
         If None, the jacobian will not be calculated. Otherwise, this should be
         an (n x m + 2) matrix representing the jacobian of each r with respect
@@ -211,15 +208,12 @@ def obj_func(to_opt: np.ndarray, colvars: np.ndarray, is_accepted: np.ndarray,
         - to_opt[0] : p_0 term
         - to_opt[1] : alpha_0, i.e. the constant added weight
         - to_opt[2:] : alphas_1...alphas_m for m collective variables.
-
     colvars:
         an (n x m) matrix where n is the number of shooting points and m is
         the number of collective variables.
-
     is_accepted:
         A length n boolean np array corresponding to if the ith state in colvars
         was accepted
-
     calc_jac:
         True if the jacobian should be calculated and also returned
 

--- a/transition_sampling/likelihood/optimization.py
+++ b/transition_sampling/likelihood/optimization.py
@@ -8,11 +8,14 @@ to the reaction coordinate.
 """
 from __future__ import annotations
 
+from typing import Optional
+import typing
+
 from scipy.optimize import basinhopping
 import numpy as np
 
 
-def optimize(colvars, is_accepted, niter=100) -> np.ndarray:
+def optimize(colvars, is_accepted, niter=100, use_jac=True) -> np.ndarray:
     """
     Use basinhopping for global optimization of rxn coords as a linear
     combination of CVs.
@@ -46,6 +49,11 @@ def optimize(colvars, is_accepted, niter=100) -> np.ndarray:
         Number of local optimizations to perform with basinhopping. Linearly
         scales.
 
+    use_jac
+        True if the analytical jacobian should be used during gradient descent.
+        Otherwise, the default finite difference approximation will be used.
+        In most cases, enabling this offers a speedup
+
     Returns
     -------
         Array of length (m+2) of optimized parameters as [p0, alpha0, alphas]
@@ -66,23 +74,24 @@ def optimize(colvars, is_accepted, niter=100) -> np.ndarray:
 
     # Setting jac = True indicates that the objective function also returns
     # the jacobian
-    min_args = {"args": (colvars, is_accepted), "bounds": bnds, "jac": True}
+    min_args = {"args": (colvars, is_accepted, use_jac),
+                "bounds": bnds,
+                "jac": use_jac,
+                "method": "L-BFGS-B"}
 
     sol = basinhopping(obj_func, x0, niter=niter, minimizer_kwargs=min_args)
-
-    # if not sol.success:
-    #     raise RuntimeWarning(f"Solution did not converge {sol}")
 
     return sol.x
 
 
 # Let n refer to the number of shooting points and m refer to the number of CVs
 
-def calc_r(alphas: np.ndarray,
-           colvars: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def calc_r(alphas: np.ndarray, colvars: np.ndarray,
+           calc_jac: bool) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Calculate linear combination of reaction coordinates given a weights vector
-    and colvars matrix. Also returns the jacobian with respect to the alphas.
+    and colvars matrix. Also returns the jacobian with respect to the alphas if
+    requested.
 
     Parameters
     ----------
@@ -94,6 +103,9 @@ def calc_r(alphas: np.ndarray,
         an (n x m) matrix where n is the number of shooting points and m is
         the number of collective variables.
 
+    calc_jac
+        True if the jacobian should be calculated and returned.
+
     Returns
     -------
     A tuple of two numpy arrays.
@@ -101,9 +113,10 @@ def calc_r(alphas: np.ndarray,
         A length n vector of calculated reaction coordinates, one for each
         shooting point.
     Second term:
-        An (n x m + 2) matrix representing the jacobian of each coordinate with
-        respect to each alpha. The 0 index column is empty space allocated for
-        p_0 later on. Columns 1:m+2 represent jacobians of the alphas
+        None if `calc_jac` = False. Otherwise, an (n x m + 2) matrix
+        representing the jacobian of each  coordinate with respect to each
+        alpha. The 0 index column is empty space allocated for p_0 later on.
+        Columns 1:m+2 represent jacobians of the alphas
     """
     r_vals = alphas[0] + np.matmul(colvars, alphas[1:])
 
@@ -111,17 +124,18 @@ def calc_r(alphas: np.ndarray,
     r_jacobian = np.zeros((colvars.shape[0], alphas.size + 1))
     # second column is d/dalpha_0 (all ones since constant)
     r_jacobian[:, 1] = 1
-    # rest is just the d/dalphas, which are just the respective colvars since
-    # the alphas are the coefficients
+    # rest is just the d/dalphas, which are just the respective colvars
+    # since the alphas are the coefficients
     r_jacobian[:, 2:] = colvars
+
     return r_vals, r_jacobian
 
 
 def calc_p(p_0: float, r_vals: np.ndarray,
-           r_jac: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+           r_jac: np.ndarray) -> tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Calculate P(TP|r) for reaction coordinate given a weights vector and
-    colvars. Also returns the jacobian.
+    colvars. Also returns the jacobian if requested.
 
     Parameters
     ----------
@@ -132,7 +146,8 @@ def calc_p(p_0: float, r_vals: np.ndarray,
         A length n vector of calculated reaction coordinates.
 
     r_jac
-        An (n x m + 2) matrix representing the jacobian of each r with respect
+        If None, the jacobian will not be calculated. Otherwise, this should be
+        an (n x m + 2) matrix representing the jacobian of each r with respect
         to each alpha. The 0 index column should be empty space. Columns 1:m+2
         represent jacobians of the alphas
 
@@ -142,8 +157,9 @@ def calc_p(p_0: float, r_vals: np.ndarray,
     First term:
         A length n vector of P(TP|r) for every r
     Second term:
-        An (n x m + 2) matrix representing the jacobian of each p with respect
-        to all parameters. The columns are ordered as p_0, alphas.
+        None if r_jac is None. Otherwise an (n x m + 2) matrix representing the
+        jacobian of each p with respect to all parameters. The columns are
+        ordered as p_0, alphas.
     """
     lower_threshold = 1.0e-15
     upper_threshold = 1.0 - lower_threshold
@@ -158,31 +174,34 @@ def calc_p(p_0: float, r_vals: np.ndarray,
     if np.any(p_vals > upper_threshold):
         p_vals = np.where(p_vals > upper_threshold, upper_threshold, p_vals)
 
-    # d/dr are all on diagonal since no r values affect one another here. This
-    # is a single vector representing a diagonal (n x n) matrix, all off
-    # off diagonals are 0.
-    diag_vector = -2 * p_0 * np.tanh(r_vals) * np.power(np.cosh(r_vals), -2)
+    p_jacobian = None
+    if r_jac is not None:
+        # d/dr are all on diagonal since no r values affect one another here.
+        # This is a single vector representing a diagonal (n x n) matrix,
+        # all off off diagonals are 0.
+        diag_vector = -2 * p_0 * np.tanh(r_vals) * np.power(np.cosh(r_vals), -2)
 
-    # Multiply by the r jacobian to get an (n x m+2) jacobian. This takes
-    # advantage of the diagonal to achieve a 1000x+ speedup as opposed to
-    # performing a full (n x n) x (n x m+2) matrix multiplication
+        # Multiply by the r jacobian to get an (n x m+2) jacobian. This takes
+        # advantage of the diagonal to achieve a 1000x+ speedup as opposed to
+        # performing a full (n x n) x (n x m+2) matrix multiplication
 
-    # - diag_vector.reshape(-1, 1) casts the vector to a (n, 1) shape to allow
-    # broadcasting
-    # - this is broadcasted to (n x m+2) by concatenating the column m+2 times
-    # - finally, this is elementwise multiplied to the r_jac (n x m+2). This
-    # equivalent to the full matrix multiplication.
-    p_jacobian = np.multiply(diag_vector.reshape(-1, 1), r_jac)
+        # - diag_vector.reshape(-1, 1) casts the vector to a (n, 1) shape to
+        # allow broadcasting
+        # - this is broadcasted to (n x m+2) by  concatenating the column m+2
+        # times
+        # - finally, this is elementwise multiplied to the r_jac (n x m+2).
+        # This equivalent to the full matrix multiplication.
+        p_jacobian = np.multiply(diag_vector.reshape(-1, 1), r_jac)
 
-    # update the first column, previously all 0s, because this is where p_0
-    # comes into play. p_0 is the coefficient in front of these terms.
-    p_jacobian[:, 0] = 1 - np.power(np.tanh(r_vals), 2)
+        # update the first column, previously all 0s, because this is where p_0
+        # comes into play. p_0 is the coefficient in front of these terms.
+        p_jacobian[:, 0] = 1 - np.power(np.tanh(r_vals), 2)
 
     return p_vals, p_jacobian
 
 
-def obj_func(to_opt: np.ndarray, colvars: np.ndarray,
-             is_accepted: np.ndarray) -> tuple[float, np.ndarray]:
+def obj_func(to_opt: np.ndarray, colvars: np.ndarray, is_accepted: np.ndarray,
+             calc_jac: bool) -> tuple[float, Optional[np.ndarray]]:
     """
     Objective function to minimize for colvar maximization with fixed p_0
 
@@ -202,18 +221,21 @@ def obj_func(to_opt: np.ndarray, colvars: np.ndarray,
         A length n boolean np array corresponding to if the ith state in colvars
         was accepted
 
+    calc_jac:
+        True if the jacobian should be calculated and also returned
+
     Returns
     -------
     A tuple of float, numpy array.
     First term:
         The value to be *minimized* for likelihood maximization.
     Second term:
-        m+2 length array representing the jacobian of the objective function for
-        each optimized parameter
+        None if calc_jac is None. Otherwise: an m+2 length array representing
+        the jacobian of the objective function for each optimized parameter
     """
     p_0 = to_opt[0]
     alphas = to_opt[1:]
-    r_vals, r_jac = calc_r(alphas, colvars)
+    r_vals, r_jac = calc_r(alphas, colvars, calc_jac)
     p_vals, p_jac = calc_p(p_0, r_vals, r_jac)
 
     p_accepted = p_vals[is_accepted]
@@ -222,17 +244,19 @@ def obj_func(to_opt: np.ndarray, colvars: np.ndarray,
     # -1 for minimization
     obj_val = -1 * (np.sum(np.log(p_accepted)) + np.sum(np.log(p_rejected)))
 
-    # this is (1 x n)
-    jac = np.ones(colvars.shape[0])
+    obj_jacobian = None
+    if calc_jac:
+        # this is (1 x n)
+        jac = np.ones(colvars.shape[0])
 
-    # derivatives of log of each p_val
-    jac[is_accepted] = 1 / p_accepted
-    jac[~is_accepted] = -1 / p_rejected
+        # derivatives of log of each p_val
+        jac[is_accepted] = 1 / p_accepted
+        jac[~is_accepted] = -1 / p_rejected
 
-    # -1 because of the optimization
-    jac *= -1
+        # -1 because of the optimization
+        jac *= -1
 
-    # (1 x n) x (n x m + 2) to get a (1 x m + 2) jacobian
-    obj_jacobian = np.matmul(jac, p_jac)
+        # (1 x n) x (n x m + 2) to get a (1 x m + 2) jacobian
+        obj_jacobian = np.matmul(jac, p_jac)
 
     return obj_val, obj_jacobian

--- a/transition_sampling/likelihood/optimization.py
+++ b/transition_sampling/likelihood/optimization.py
@@ -70,8 +70,8 @@ def optimize(colvars, is_accepted, niter=100) -> np.ndarray:
 
     sol = basinhopping(obj_func, x0, niter=niter, minimizer_kwargs=min_args)
 
-    if not sol.success:
-        raise RuntimeWarning(f"Solution did not converge {sol}")
+    # if not sol.success:
+    #     raise RuntimeWarning(f"Solution did not converge {sol}")
 
     return sol.x
 

--- a/transition_sampling/likelihood/optimization.py
+++ b/transition_sampling/likelihood/optimization.py
@@ -9,10 +9,9 @@ to the reaction coordinate.
 from __future__ import annotations
 
 from typing import Optional
-import typing
 
-from scipy.optimize import basinhopping
 import numpy as np
+from scipy.optimize import basinhopping
 
 
 def optimize(colvars, is_accepted, niter=100, use_jac=True) -> np.ndarray:

--- a/transition_sampling/likelihood/optimization.py
+++ b/transition_sampling/likelihood/optimization.py
@@ -14,7 +14,8 @@ import numpy as np
 from scipy.optimize import basinhopping
 
 
-def optimize(colvars, is_accepted, niter=100, use_jac=True) -> np.ndarray:
+def optimize(colvars: np.ndarray, is_accepted: np.ndarray,
+             niter: int = 100, use_jac: bool = True) -> np.ndarray:
     """
     Use basinhopping for global optimization of rxn coords as a linear
     combination of CVs.

--- a/transition_sampling/tests/likelihood_tests/test_optimization.py
+++ b/transition_sampling/tests/likelihood_tests/test_optimization.py
@@ -1,0 +1,72 @@
+import os
+from unittest import TestCase
+
+import numpy as np
+import scipy.optimize
+
+from transition_sampling.likelihood.optimization import obj_func, optimize
+
+CUR_DIR = os.path.dirname(__file__)
+PLUMED_DATA_DIR = os.path.join(CUR_DIR, "test_data/plumed")
+
+
+class TestObjectiveFunction(TestCase):
+
+    def test_jacobian(self):
+        """Tests to ensure the jacobian is calculated correctly"""
+
+        # Its very easy to get overflow/underflow errors when not being careful
+        # which lead to large differences between the finite difference and
+        # evaluated analytical solutions
+        np.random.seed(1)
+        n_states = 100
+        m_colvars = 4
+
+        for i in range(10):
+            colvars = np.random.random((n_states, m_colvars))
+            is_accepted = np.random.choice([True, False], n_states)
+
+            value = lambda x: obj_func(x, colvars, is_accepted)[0]
+            jacobian = lambda x: obj_func(x, colvars, is_accepted)[1]
+
+            for j in range(10):
+                point = np.array(np.random.random(m_colvars + 2))
+                error = scipy.optimize.check_grad(value, jacobian, point)
+
+                self.assertTrue(error < 1e-2,
+                                msg=f"Error was {error} on {i}, {j}")
+
+    def test_obj_func_works(self):
+        np.random.seed(1)
+
+        for i in range(30):
+            n_states = np.random.choice(10000)
+            m_colvars = np.random.choice(10)
+            colvars = np.random.random((n_states, m_colvars))
+            is_accepted = np.random.choice([True, False], n_states)
+            point = np.array(np.random.random(m_colvars + 2))
+
+            try:
+                obj_func(point, colvars, is_accepted)
+            except Exception as e:
+                self.fail(msg=f"Exception {e} thrown. {n_states} states,"
+                              f" {m_colvars} colvars")
+
+
+class TestOptimizer(TestCase):
+
+    def test_optimizer(self):
+        np.random.seed(2)
+
+        for i in range(5):
+            n_states = np.random.choice(1000)
+            m_colvars = np.random.choice(range(1, 4))
+            colvars = np.random.random((n_states, m_colvars))
+            is_accepted = np.random.choice([True, False], n_states)
+
+            sol = optimize(colvars, is_accepted)
+            final_jac = obj_func(sol, colvars, is_accepted)[0]
+
+            self.assertTrue(np.any(np.abs(final_jac)) > 1e-2,
+                            msg=f"{n_states} states, {m_colvars} colvars failed"
+                                f"to have a 0 jacobian: {final_jac}")

--- a/transition_sampling/tests/likelihood_tests/test_optimization.py
+++ b/transition_sampling/tests/likelihood_tests/test_optimization.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 import numpy as np
 import scipy.optimize
+import scipy.stats
 
 from transition_sampling.likelihood.optimization import obj_func, optimize
 
@@ -15,7 +16,7 @@ class TestObjectiveFunction(TestCase):
     def test_jacobian(self):
         """Tests to ensure the jacobian is calculated correctly"""
 
-        # Its very easy to get overflow/underflow errors when not being careful
+        # Its very easy to get underflow errors when not being careful
         # which lead to large differences between the finite difference and
         # evaluated analytical solutions
         np.random.seed(1)
@@ -26,8 +27,8 @@ class TestObjectiveFunction(TestCase):
             colvars = np.random.random((n_states, m_colvars))
             is_accepted = np.random.choice([True, False], n_states)
 
-            value = lambda x: obj_func(x, colvars, is_accepted)[0]
-            jacobian = lambda x: obj_func(x, colvars, is_accepted)[1]
+            value = lambda x: obj_func(x, colvars, is_accepted, False)[0]
+            jacobian = lambda x: obj_func(x, colvars, is_accepted, True)[1]
 
             for j in range(10):
                 point = np.array(np.random.random(m_colvars + 2))
@@ -37,6 +38,7 @@ class TestObjectiveFunction(TestCase):
                                 msg=f"Error was {error} on {i}, {j}")
 
     def test_obj_func_works(self):
+        """Test objective function with different shapes of inputs"""
         np.random.seed(1)
 
         for i in range(30):
@@ -47,26 +49,70 @@ class TestObjectiveFunction(TestCase):
             point = np.array(np.random.random(m_colvars + 2))
 
             try:
-                obj_func(point, colvars, is_accepted)
+                obj_func(point, colvars, is_accepted, True)
             except Exception as e:
                 self.fail(msg=f"Exception {e} thrown. {n_states} states,"
                               f" {m_colvars} colvars")
 
 
 class TestOptimizer(TestCase):
+    """Test that the optimizer converges with fake data."""
 
     def test_optimizer(self):
+        """Generate random orthogonal CVs and a random separating surface.
+
+        Accept CVs closer to the generated surface with a normally distributed
+        probability, centered on the surface. Confirm that the optimizer is able
+        to find this underlying surface a minimum.
+        """
         np.random.seed(2)
+        std = 0.3
 
         for i in range(5):
-            n_states = np.random.choice(1000)
-            m_colvars = np.random.choice(range(1, 4))
-            colvars = np.random.random((n_states, m_colvars))
-            is_accepted = np.random.choice([True, False], n_states)
+            n_states = np.random.choice(range(1000, 5000))
+            m_colvars = np.random.choice(range(2, 4))
 
-            sol = optimize(colvars, is_accepted)
-            final_jac = obj_func(sol, colvars, is_accepted)[0]
+            # Our CV data, randomly distributed between [-1, 1]
+            cvs = np.random.random_sample((n_states, m_colvars)) * 2 - 1
 
-            self.assertTrue(np.any(np.abs(final_jac)) > 1e-2,
-                            msg=f"{n_states} states, {m_colvars} colvars failed"
-                                f"to have a 0 jacobian: {final_jac}")
+            # Separating surface given by constant offset and normal vector
+            # This is a hyper plane in R^(m_colvars)
+            surf_offset = np.random.random(1)[0]
+            surf_vector = np.random.random(m_colvars)
+            surf_norm = np.linalg.norm(surf_vector)
+
+            distances = (np.dot(cvs, surf_vector) + surf_offset) / surf_norm
+
+            max_val = scipy.stats.norm.pdf(0, 0, std)
+
+            # Make the centered location have a probability of 1
+            # not a true PDF!
+            probs = scipy.stats.norm.pdf(distances, 0, std) / max_val
+
+            # Randomly accept or reject a state based on its distance's prob.
+            is_accepted = np.array(
+                [np.random.choice([True, False], 1, p=[prob, 1 - prob]) for prob
+                 in probs]).reshape(-1)
+
+            sol = optimize(cvs, is_accepted, use_jac=True)
+            final_jac = obj_func(sol, cvs, is_accepted, True)[1]
+
+            # Check that derivatives are close to 0, i.e. at a minimum
+            # The p0 jacobian can be non zero because its bounded.
+            self.assertFalse(np.any(np.abs(final_jac[1:]) > 1e-3),
+                             msg=f"{n_states} states, {m_colvars} colvars failed"
+                                 f" to have a 0 jacobian: {final_jac} (first entry okay)")
+
+            # Both the constant offset and vector need to be normalized by the
+            # distance of the vector to compare
+            comparable_surf = np.append(np.array([surf_offset]),
+                                        surf_vector) / surf_norm
+
+            # Same normalization for our solution
+            comparable_opt = sol[1:] / np.linalg.norm(sol[2:])
+
+            # Compare that all values are close
+            self.assertTrue(np.allclose(comparable_surf, comparable_opt,
+                                        rtol=0.1, atol=1e-2),
+                            msg=f"{n_states} states, {m_colvars} colvars failed, "
+                                f"true: {comparable_surf}, actual: {comparable_opt}")


### PR DESCRIPTION
Introduces all the calculations needed to maximize the likelihood of one set of CVs through the main function `optimize`. This uses basinhopping to find the global max, so `niters` can be used to change the total number of local optimizations that happen, drastically altering runtime. The analytical jacobian can also optionally be used to (generally) speed up this optimization.

Tests for:
 - jacobian correctness as compared to finite difference
 - general use of the objective function with different shapes of input
 - Optimization to find a known underlying dividing surface