### PR TITLE
Logging

### DIFF
--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -95,7 +95,7 @@ class AimlessShootingDriver:
         tasks = []
         base_results_logger = ResultsLogger(self.log_name)
         for i in range(n_parallel):
-            logger = logging.getLogger(f"{__name__}_{i}")
+            logger = logging.getLogger(f"{__name__}.{i}")
             logger.setLevel(module_logger.level)
             engine = copy.deepcopy(self.base_engine)
             engine.logger = logger

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -17,6 +17,8 @@ import transition_sampling.util.xyz as xyz
 from transition_sampling.util.periodic_table import atomic_symbols_to_mass
 from transition_sampling.engines import AbstractEngine, ShootingResult
 
+module_logger = logging.getLogger(__name__)
+
 
 class AimlessShootingDriver:
     """Driver to run one or multiple aimless shootings.
@@ -74,7 +76,7 @@ class AimlessShootingDriver:
         run_args
             Keyword arguments to pass to each aimless shootings `run` method.
         """
-        logging.info("Starting %s parallel aimless shootings", n_parallel)
+        module_logger.info("Starting %s parallel aimless shootings", n_parallel)
         asyncio.run(self._gather_runs(n_parallel, **run_args))
 
     async def _gather_runs(self, n_parallel: int, **run_args) -> None:
@@ -93,7 +95,8 @@ class AimlessShootingDriver:
         tasks = []
         base_results_logger = ResultsLogger(self.log_name)
         for i in range(n_parallel):
-            logger = logging.getLogger(f"aimless_{i}")
+            logger = logging.getLogger(f"{__name__}_{i}")
+            logger.setLevel(module_logger.level)
             engine = copy.deepcopy(self.base_engine)
             engine.logger = logger
 
@@ -157,7 +160,7 @@ class AsyncAimlessShooting:
                  results_logger: ResultsLogger, acceptor: AbstractAcceptor = None,
                  logger: logging.Logger = None):
         if logger is None:
-            self.logger = logging.getLogger(__name__)
+            self.logger = module_logger
         else:
             self.logger = logger
 

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -55,6 +55,7 @@ class AimlessShootingDriver:
     base_acceptor : AbstractAcceptor
         Acceptor template to be used for all shootings
     """
+
     def __init__(self, engine: AbstractEngine, position_dir: str, log_name: str,
                  acceptor: AbstractAcceptor = None):
         self.base_engine = engine
@@ -156,6 +157,7 @@ class AsyncAimlessShooting:
         An acceptor that implements an `is_accepted` method to determine if a
         shooting point should be considered accepted or not.
     """
+
     def __init__(self, engine: AbstractEngine, position_dir: str,
                  results_logger: ResultsLogger, acceptor: AbstractAcceptor = None,
                  logger: logging.Logger = None):
@@ -239,11 +241,10 @@ class AsyncAimlessShooting:
                                  "previously accepted state", n_vel_tries)
                 states_since_success += 1
                 if states_since_success == n_state_tries:
-                    raise RuntimeError(
-                        f"Next transition state not found in {n_state_tries} "
-                        f"state tries and {n_vel_tries} velocity tries "
-                        f"({n_state_tries * n_vel_tries}) total unsuccessful "
-                        f"runs in a row")
+                    self.logger.error("Next transition state not found in %s "
+                                      "state tries and %s velocity tries (%s) "
+                                      "total unsuccessful runs in a row",
+                                      n_state_tries, n_vel_tries, n_state_tries * n_vel_tries)
 
                 # randomly choose a new start from the list that we know works
                 self.current_start = random.choice(self.accepted_states)
@@ -468,8 +469,8 @@ class AsyncAimlessShooting:
         True if it should be accepted, False otherwise.
         """
         return result.fwd["commit"] is not None and \
-            result.rev["commit"] is not None and \
-            result.fwd["commit"] != result.rev["commit"]
+               result.rev["commit"] is not None and \
+               result.fwd["commit"] != result.rev["commit"]
 
 
 class ResultsLogger:
@@ -505,6 +506,7 @@ class ResultsLogger:
     cur_index : int
         The next index that will be written in the CSV.
     """
+
     def __init__(self, name: str, base_logger: ResultsLogger = None):
         self.name = name
         self.base_logger = base_logger
@@ -601,9 +603,9 @@ def generate_velocities(atoms: Sequence[str], temp: float) -> np.array:
     distribution. Has the shape (n_atoms, 3), where 3 is the x,y,z directions.
     """
 
-    kB = 1.380649e-23            # J / K
+    kB = 1.380649e-23  # J / K
     au_time_factor = 0.0242e-15  # s / au_time
-    bohr_factor = 5.29e-11       # m / bohr
+    bohr_factor = 5.29e-11  # m / bohr
 
     mass = atomic_symbols_to_mass(atoms)
     n_atoms = len(mass)

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -157,7 +157,7 @@ class AsyncAimlessShooting:
                  results_logger: ResultsLogger, acceptor: AbstractAcceptor = None,
                  logger: logging.Logger = None):
         if logger is None:
-            self.logger = logging
+            self.logger = logging.getLogger(__name__)
         else:
             self.logger = logger
 

--- a/transition_sampling/colvar/plumed_driver.py
+++ b/transition_sampling/colvar/plumed_driver.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import subprocess
 import tempfile
@@ -41,6 +42,9 @@ class PlumedDriver:
             plumed string representation of the xyz units, passed directly to
             plumed.
         """
+        logging.info("running plumed with plumed: %s, xyz: %s, csv: %s",
+                     plumed_file, xyz_file, csv_file)
+
         with tempfile.NamedTemporaryFile("a") as running_file:
             self._set_output(plumed_file, colvar_output, running_file)
 
@@ -52,7 +56,7 @@ class PlumedDriver:
 
             box_string = ",".join([str(x) for x in box_sizes])
 
-            # TODO: Log a failure rather than fatal exception w/ plumed output
+            # TODO: Log a failure rather than fatal exception w/ plumed output (is this still needed?)
             # Hide typical stdout, but stderr will still print
             subprocess.run([*self.plumed_cmd, "driver", "--ixyz", xyz_file,
                             "--plumed", running_file.name, "--box", box_string,

--- a/transition_sampling/colvar/plumed_driver.py
+++ b/transition_sampling/colvar/plumed_driver.py
@@ -6,6 +6,8 @@ import typing
 
 import pandas as pd
 
+logger = logging.getLogger(__name__)
+
 
 class PlumedDriver:
     """Interfaces with the Plumed Driver to calculate CVs.
@@ -42,8 +44,8 @@ class PlumedDriver:
             plumed string representation of the xyz units, passed directly to
             plumed.
         """
-        logging.info("running plumed with plumed: %s, xyz: %s, csv: %s",
-                     plumed_file, xyz_file, csv_file)
+        logger.info("running plumed with plumed: %s, xyz: %s, csv: %s",
+                    plumed_file, xyz_file, csv_file)
 
         with tempfile.NamedTemporaryFile("a") as running_file:
             self._set_output(plumed_file, colvar_output, running_file)

--- a/transition_sampling/driver.py
+++ b/transition_sampling/driver.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 
 from .colvar import PlumedDriver
@@ -313,8 +314,17 @@ def read_and_run(input_yml: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="YAML file with all required inputs")
+
+    levels = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+    parser.add_argument('--log-level', default='INFO', choices=levels,
+                        help="Granularity of logging to print at")
+    parser.add_argument("--log-file", default="aimless.log",
+                        help="File to output log to")
     args = parser.parse_args()
-    
+
+    logging.basicConfig(filename=args.log_file, level=args.log_level,
+                        format='%(asctime)s %(levelname)s %(name)s %(message)s')
+
     read_and_run(args.input)
 
 

--- a/transition_sampling/driver.py
+++ b/transition_sampling/driver.py
@@ -12,6 +12,8 @@ import sys
 
 from schema import Schema, And, Optional, Use, Or
 
+logger = logging.getLogger(__name__)
+
 master_schema = Schema({Optional("md_inputs"): dict,
                         Optional("colvar_inputs"): dict,
                         Optional("likelihood_inputs"): dict})
@@ -322,8 +324,10 @@ def main():
                         help="File to output log to")
     args = parser.parse_args()
 
-    logging.basicConfig(filename=args.log_file, level=args.log_level,
-                        format='%(asctime)s %(levelname)s %(name)s %(message)s')
+    fh = logging.FileHandler(args.log_file)
+    fh.setLevel(args.log_level)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    logger.addHandler(fh)
 
     read_and_run(args.input)
 

--- a/transition_sampling/driver.py
+++ b/transition_sampling/driver.py
@@ -12,7 +12,7 @@ import sys
 
 from schema import Schema, And, Optional, Use, Or
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("transition_sampling")
 
 master_schema = Schema({Optional("md_inputs"): dict,
                         Optional("colvar_inputs"): dict,
@@ -328,6 +328,7 @@ def main():
     fh.setLevel(args.log_level)
     fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
     logger.addHandler(fh)
+    logger.setLevel(args.log_level)
 
     read_and_run(args.input)
 

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -294,6 +294,7 @@ class AbstractEngine(ABC):
 
         # random project name so we don't overwrite/append anything
         proj_name = uuid.uuid4().hex
+        self.logger.info("Launching shooting point %s", proj_name)
 
         tasks = (self._launch_traj_fwd(proj_name),
                  self._launch_traj_rev(proj_name))

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -125,7 +125,7 @@ class AbstractEngine(ABC):
             working directory is not a real directory.
         """
         if logger is None:
-            self.logger = logging
+            self.logger = logging.getLogger(__name__)
         else:
             self.logger = logger
 

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -5,6 +5,7 @@ order to be used by the aimless shooting algorithm
 from __future__ import annotations
 
 import glob
+import logging
 import numbers
 import os
 from abc import ABC, abstractmethod
@@ -101,7 +102,8 @@ class AbstractEngine(ABC):
     """
 
     @abstractmethod
-    def __init__(self, inputs: dict, working_dir: str = None):
+    def __init__(self, inputs: dict, working_dir: str = None,
+                 logger: logging.Logger = None):
         """Create an engine.
 
         Pass the required inputs and a working directory for the engine to write
@@ -122,6 +124,11 @@ class AbstractEngine(ABC):
             if inputs are not valid for the concrete engine class or if a given
             working directory is not a real directory.
         """
+        if logger is None:
+            self.logger = logging
+        else:
+            self.logger = logger
+
         validation_res = self.validate_inputs(inputs)
         if not validation_res[0]:
             raise ValueError(f"Invalid inputs: {validation_res[1]}")

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -197,7 +197,7 @@ class CP2KEngine(AbstractEngine):
 
         command_list = [*self.cmd, "-i", input_path, "-o", f"{projname}.out"]
         self.logger.debug("Launching trajectory %s with command %s", projname, command_list)
-        
+
         # Start cp2k, expanding the list of commands and setting input/output
         proc = subprocess.Popen(command_list, cwd=self.working_dir,
                                 stderr=subprocess.PIPE,
@@ -233,7 +233,7 @@ class CP2KEngine(AbstractEngine):
                 f.write("\nSTDERR: \n")
                 f.write(stderror_msg)
 
-            self.logger.warning("Trajectory %s exited fatally:\n  stdout: %s\n  stderr:",
+            self.logger.warning("Trajectory %s exited fatally:\n  stdout: %s\n  stderr: %s",
                                 projname, stdout_msg, stderror_msg)
             raise RuntimeError(f"Trajectory {projname} failed")
 

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -42,10 +42,10 @@ class CP2KEngine(AbstractEngine):
         manipulation of the inputs.
     """
 
-    def __init__(self, inputs: dict, working_dir: str = None):
-        super().__init__(inputs, working_dir)
+    def __init__(self, inputs: dict, working_dir: str = None, **kwargs):
+        super().__init__(inputs, working_dir, **kwargs)
 
-        self.cp2k_inputs = CP2KInputsHandler(inputs["cp2k_inputs"])
+        self.cp2k_inputs = CP2KInputsHandler(inputs["cp2k_inputs"], self.logger)
 
         self.set_delta_t(inputs["delta_t"])
 
@@ -95,12 +95,18 @@ class CP2KEngine(AbstractEngine):
 
         # random project name so we don't overwrite/append anything
         proj_name = uuid.uuid4().hex
+        self.logger.info("Launching shooting point %s", proj_name)
 
         tasks = (self._launch_traj_fwd(proj_name),
                  self._launch_traj_rev(proj_name))
 
         # Wait until both tasks are complete
         result = await asyncio.gather(*tasks)
+
+        # if something went wrong with either, return None
+        if result[0] is None or result[1] is None:
+            return None
+
         return ShootingResult(result[0], result[1])
 
     def set_delta_t(self, value: float) -> None:
@@ -109,6 +115,8 @@ class CP2KEngine(AbstractEngine):
         # looking at printed frames
         timestep = self.cp2k_inputs.read_timestep()
         frames_in_dt = int(np.round(value / timestep))
+        self.logger.info("dt of %s fs set, corresponding to %s md frames",
+                         value, frames_in_dt)
 
         self.cp2k_inputs.set_traj_print_freq(frames_in_dt)
 
@@ -187,10 +195,11 @@ class CP2KEngine(AbstractEngine):
         input_path = os.path.join(self.working_dir, f"{projname}.inp")
         self.cp2k_inputs.write_cp2k_inputs(input_path)
 
+        command_list = [*self.cmd, "-i", input_path, "-o", f"{projname}.out"]
+        self.logger.debug("Launching trajectory %s with command %s", projname, command_list)
+        
         # Start cp2k, expanding the list of commands and setting input/output
-        proc = subprocess.Popen([*self.cmd, "-i", input_path, "-o",
-                                 f"{projname}.out"],
-                                cwd=self.working_dir,
+        proc = subprocess.Popen(command_list, cwd=self.working_dir,
                                 stderr=subprocess.PIPE,
                                 stdout=subprocess.PIPE)
 
@@ -213,22 +222,26 @@ class CP2KEngine(AbstractEngine):
             output_file = f"{projname}_FATAL.out"
             output_handler.copy_out_file(output_file)
 
+            stdout_msg = stdout.decode('ascii')
+            stderror_msg = stderr.decode('ascii')
+
             # Append the error from stdout to the output file
             with open(output_file, "a") as f:
                 f.write("\nFAILURE \n")
                 f.write("STDOUT: \n")
-                f.write(stdout.decode('ascii'))
+                f.write(stdout_msg)
                 f.write("\nSTDERR: \n")
-                f.write(stderr.decode('ascii'))
+                f.write(stderror_msg)
 
-            raise RuntimeError("Process failed")
+            self.logger.warning("Trajectory %s exited fatally:\n  stdout: %s\n  stderr:",
+                                projname, stdout_msg, stderror_msg)
+            raise RuntimeError(f"Trajectory {projname} failed")
 
         # Get the output file for warnings. If there are some, log them
         warnings = output_handler.check_warnings()
         if len(warnings) != 0:
-            # TODO: Log warnings better
-            logging.warning("CP2K run of %s generated warnings: %s",
-                            projname, warnings)
+            self.logger.warning("CP2K trajectory %s generated warnings: %s",
+                                projname, warnings)
 
         parser = PlumedOutputHandler(plumed_out_path)
         basin = parser.check_basin()
@@ -239,10 +252,22 @@ class CP2KEngine(AbstractEngine):
         # should still work in that case
         if basin is not None:
             self._remove_core_dumps()
-            print(f"{projname} committed to basin {basin}.")
+            self.logger.info("Trajectory %s committed to basin %s", projname,
+                             basin)
+        else:
+            self.logger.info("Trajectory %s did not commit before simulation ended",
+                             projname)
 
-        return {"commit": basin,
-                "frames": output_handler.read_frames_2_3()}
+        try:
+            return {"commit": basin,
+                    "frames": output_handler.read_frames_2_3()}
+        except EOFError:
+            self.logger.warning("Required frames could not be be read from the"
+                                " output trajectory. This may be cased by a delta_t"
+                                " that is too large where the traj committed to a"
+                                " basin before 2*delta_t fs or a simulation wall time"
+                                " that is too short and exited before reaching 2*delta_t fs")
+            return None
 
     def _remove_core_dumps(self) -> None:
         """Remove all core files from the working directory"""

--- a/transition_sampling/engines/cp2k/CP2K_inputs.py
+++ b/transition_sampling/engines/cp2k/CP2K_inputs.py
@@ -28,7 +28,7 @@ class CP2KInputsHandler:
 
     def __init__(self, cp2k_inputs_file: str, logger: logging.Logger = None):
         if logger is None:
-            self.logger = logging
+            self.logger = logging.getLogger(__name__)
         else:
             self.logger = logger
 

--- a/transition_sampling/engines/cp2k/CP2K_inputs.py
+++ b/transition_sampling/engines/cp2k/CP2K_inputs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from cp2k_input_tools.generator import CP2KInputGenerator
 from cp2k_input_tools.parser import CP2KInputParser
@@ -24,7 +26,12 @@ class CP2KInputsHandler:
         The in-memory data structure representing the current inputs
     """
 
-    def __init__(self, cp2k_inputs_file: str):
+    def __init__(self, cp2k_inputs_file: str, logger: logging.Logger = None):
+        if logger is None:
+            self.logger = logging
+        else:
+            self.logger = logger
+
         with open(cp2k_inputs_file) as f:
             parser = CP2KInputParser()
             self.cp2k_dict = parser.parse(f)
@@ -47,6 +54,7 @@ class CP2KInputsHandler:
             # TODO: How does this handle coordinates linked in a separate file?
             # Return the first two places for each coordinate entry
             self._atoms = [entry[0:2].strip() for entry in self._get_coord()]
+            self.logger.debug("Atoms %s identified in input file", self._atoms)
 
         return self._atoms
 

--- a/transition_sampling/likelihood/likelihood_max.py
+++ b/transition_sampling/likelihood/likelihood_max.py
@@ -124,7 +124,7 @@ class Maximizer:
 
         logger.info("Starting maximization with colvars: %s, required "
                     "improvement: %s, max length of combination to try: %s",
-                    available_colvars, result.req_improvement, max_num_cvs)
+                    available_colvars.values, result.req_improvement, max_num_cvs)
 
         # Do while loop according to PEP 315. Will at least evaluate all single
         # CVs and all pairs of CVs given appropriate max_num_cvs

--- a/transition_sampling/likelihood/likelihood_max.py
+++ b/transition_sampling/likelihood/likelihood_max.py
@@ -12,6 +12,8 @@ import pandas as pd
 
 from . import optimize
 
+logger = logging.getLogger(__name__)
+
 
 class Maximizer:
     """
@@ -120,9 +122,9 @@ class Maximizer:
         if max_num_cvs is None:
             max_num_cvs = len(available_colvars)
 
-        logging.info("Starting maximization with colvars: %s, required "
-                     "improvement: %s, max length of combination to try: %s",
-                     available_colvars, result.req_improvement, max_num_cvs)
+        logger.info("Starting maximization with colvars: %s, required "
+                    "improvement: %s, max length of combination to try: %s",
+                    available_colvars, result.req_improvement, max_num_cvs)
 
         # Do while loop according to PEP 315. Will at least evaluate all single
         # CVs and all pairs of CVs given appropriate max_num_cvs
@@ -136,7 +138,7 @@ class Maximizer:
             for cv_comb in combinations(available_colvars, num_cvs):
                 cur_sol = self._optimize_set(cv_comb)
                 result.combinations[num_cvs][frozenset(cv_comb)] = cur_sol
-                logging.info("Combination %s optimized to %s", cv_comb, cur_sol.obj)
+                logger.info("Combination %s optimized to %s", cv_comb, cur_sol.obj)
 
                 if cur_sol.obj > max_sol.obj:
                     max_sol = cur_sol
@@ -145,19 +147,19 @@ class Maximizer:
             # continue to do more
             if max_sol.obj - result.max.obj > result.req_improvement:
                 result.max = max_sol
-                logging.info("Improved enough to proceed. CVs %s optimized to %s",
-                             max_sol.comb, max_sol.obj)
+                logger.info("Improved enough to proceed. CVs %s optimized to %s",
+                            max_sol.comb, max_sol.obj)
 
                 # Exit if there are no more CVs to maximize
                 if num_cvs == len(available_colvars):
-                    logging.info("All possible combinations evaluated")
+                    logger.info("All possible combinations evaluated")
                     break
                 else:
                     num_cvs += 1
 
             else:
-                logging.info("No combinations with length %s improved enough to"
-                             " continue", num_cvs)
+                logger.info("No combinations with length %s improved enough to"
+                            " continue", num_cvs)
                 break
 
         return result

--- a/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
+++ b/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
@@ -36,8 +36,11 @@ class End2End(TestCase):
         inputs["md_inputs"]["engine_inputs"]["engine_dir"] = WORKING_DIR
         np.random.seed(123)
         random.seed(123)
-        logging.basicConfig(level="INFO",
-                            format='%(asctime)s %(levelname)s %(name)s %(message)s')
+        fh = logging.StreamHandler()
+        fh.setLevel("INFO")
+
+        fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+        logging.getLogger("transition_sampling").addHandler(fh)
         execute(inputs)
 
         # Not sure how best to test this other than making sure the results

--- a/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
+++ b/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
@@ -36,11 +36,15 @@ class End2End(TestCase):
         inputs["md_inputs"]["engine_inputs"]["engine_dir"] = WORKING_DIR
         np.random.seed(123)
         random.seed(123)
+
+        # Log INFO to console
         fh = logging.StreamHandler()
         fh.setLevel("INFO")
-
         fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
-        logging.getLogger("transition_sampling").addHandler(fh)
+        logger = logging.getLogger("transition_sampling")
+        logger.addHandler(fh)
+        logger.setLevel("INFO")
+
         execute(inputs)
 
         # Not sure how best to test this other than making sure the results

--- a/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
+++ b/transition_sampling/tests/integration_tests/end2end_tests/test_end2end.py
@@ -1,9 +1,12 @@
-import os
 import glob
-from unittest import TestCase
-import yaml
-import numpy as np
+import logging
+import os
 import random
+from unittest import TestCase
+
+import numpy as np
+import yaml
+
 from transition_sampling.driver import execute
 
 CUR_DIR = os.path.dirname(__file__)
@@ -33,6 +36,8 @@ class End2End(TestCase):
         inputs["md_inputs"]["engine_inputs"]["engine_dir"] = WORKING_DIR
         np.random.seed(123)
         random.seed(123)
+        logging.basicConfig(level="INFO",
+                            format='%(asctime)s %(levelname)s %(name)s %(message)s')
         execute(inputs)
 
         # Not sure how best to test this other than making sure the results


### PR DESCRIPTION
Adds logging hooks to every module, with most falling under `INFO` for typical usage, `DEBUG` for more information about what states are being chosen, etc., `WARNING` if we have something of note (e.g. CP2K gives a warning) and `ERROR` when one parallel aimless shooting runner fails to get an accepted after the given amount of times.

Logging is setup to follow the package structure, with the root logger being named `transition_sampling`. Settings for this logger trickle down to all child loggers because they are named with `__name__`, which includes the package prefix. 

For aimless shooting and MD engines, we want to be able to log to the specific instance of parallel aimless shooting, rather than all going to the same module level. When shootings are spawned, they add a `.{i}` to the module logger name, thus making each distinct. Aimless shootings and engines optionally take this logger when constructed. If not assigned, they fall back on their module level logger.

Logging for the package is initialized in the CLI driver, with defaults of `INFO` level and `aimless.log` file. These can be specified directly with command line inputs `--log-level` and `--log-file`, e.g.
```
aimless_driver input.yml --log-level DEBUG --log-file log.log
```