### PR TITLE
Add mdp handler for GROMACS

### DIFF
--- a/transition_sampling/engines/gromacs/__init__.py
+++ b/transition_sampling/engines/gromacs/__init__.py
@@ -1,0 +1,1 @@
+from .mdp import MDPHandler

--- a/transition_sampling/engines/gromacs/mdp.py
+++ b/transition_sampling/engines/gromacs/mdp.py
@@ -1,0 +1,115 @@
+import os
+import re
+
+
+# General plan: Read the whole templated MDP file into memory, only search for
+# the parts we need with regex. Since gromacs takes the last values in the file,
+# we can just append any modifications to the end of the mdp file
+
+# Things to read
+#   timestep - lets us modify print to print every dt
+
+# Things to modify
+#   nstxout - set this to be the correct number of steps such that dt time passes
+#         between each print
+#   gen-vel no - set so our input vels get used
+
+class MDPHandler:
+    """Handles reading and modifying a GROMACS .mdp file
+
+    This class is used to read a template .mdp file into memory and read its dt
+    (simulation time step value). It then allows the trajectory print frequency
+    (nstxout) to be modified, and the modified version written to disk at a new
+    location
+
+    Will not modify the original file. The original file is read once at init
+    and no modifications to it after this object is constructed will carry over.
+
+    Parameters
+    ----------
+    filename
+        path to the .mdp file. This file will not be modified.
+
+    Attributes
+    ----------
+    raw_string : str
+        The raw contents of the original .mdp stored in a string
+    print_freq : str
+        The print frequency that has been set in # of MD frames. None if it has
+        not be set with `set_traj_print_freq`
+
+    Raises
+    ------
+    ValueError
+        If `filename` is not a file.
+    """
+
+    def __init__(self, filename):
+        if not os.path.isfile(filename):
+            raise ValueError("gromacs file must a valid file")
+
+        # read the whole file into memory, search it for dt, and write it as
+        # needed later on
+        with open(filename, "r") as file:
+            self.raw_string = file.read()
+        self._timestep = self._read_timestep(self.raw_string)
+
+        self.print_freq = None
+
+    @property
+    def timestep(self):
+        """Returns the timestep of the .mdp in fs (note GROMACS uses ps)"""
+        return self._timestep
+
+    def write_mdp(self, filename):
+        """Write the MDP to the passed file with new print frequency, if any.
+
+        Overwrites anything present. Also turns off GROMACS velocity generation.
+
+        Parameters
+        ----------
+        filename
+            The file to write the input to
+        """
+        with open(filename, "w") as file:
+            file.write(self.raw_string)
+            file.write("\ngen-vel = no\n")  # ensure our set velocity is used
+
+            if self.print_freq:
+                file.write(f"nstxout = {self.print_freq}")
+
+    def set_traj_print_freq(self, step: int) -> None:
+        """Set how often the trajectory should be printed
+
+        Parameters
+        ----------
+        step
+            The number of MD steps between each print. Must be an integer and
+            must be greater than 0
+
+        Raises
+        ------
+        ValueError
+            if step is not an integer or greater than 0
+        """
+        if not isinstance(step, int):
+            raise ValueError("Step must be an integer")
+        if step <= 0:
+            raise ValueError("Step must be greater than 0")
+        self.print_freq = step
+
+    @staticmethod
+    def _read_timestep(string) -> float:
+        """Return timestep in fs"""
+        # Note that [^\S\r\n] just means to match any whitespace on the same line
+        # and not match any new lines. Matches dt = <some decimal>
+        pattern = re.compile(r"^[^\S\r\n]*dt[^\S\r\n]*=[^\S\r\n]*"
+                             r"(?P<value>\d*\.\d*)[^\S\r\n]*$", re.MULTILINE)
+        match = pattern.search(string)
+
+        if not match:
+            # default timestep is 0.001ps
+            return 1
+
+        # Gromacs uses ps units here, convert to fs
+        return float(match.group("value")) * 1000

--- a/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input.mdp
+++ b/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input.mdp
@@ -1,0 +1,30 @@
+integrator               = md
+dt                       = 0.002
+nsteps                   = 500000
+
+nstlog                   = 5000
+nstenergy                = 5000
+nstxout-compressed       = 5000
+
+continuation             = yes
+constraints              = all-bonds
+constraint-algorithm     = lincs
+
+cutoff-scheme            = Verlet
+
+coulombtype              = PME
+rcoulomb                 = 1.0
+
+vdwtype                  = Cut-off
+rvdw                     = 1.0
+DispCorr                 = EnerPres
+
+tcoupl                   = V-rescale
+tc-grps                  = Protein  SOL
+tau-t                    = 0.1      0.1
+ref-t                    = 300      300
+
+pcoupl                   = Parrinello-Rahman
+tau-p                    = 2.0
+compressibility          = 4.5e-5
+ref-p                    = 1.0

--- a/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_no_dt.mdp
+++ b/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_no_dt.mdp
@@ -1,0 +1,29 @@
+integrator               = md
+nsteps                   = 500000
+
+nstlog                   = 5000
+nstenergy                = 5000
+nstxout-compressed       = 5000
+
+continuation             = yes
+constraints              = all-bonds
+constraint-algorithm     = lincs
+
+cutoff-scheme            = Verlet
+
+coulombtype              = PME
+rcoulomb                 = 1.0
+
+vdwtype                  = Cut-off
+rvdw                     = 1.0
+DispCorr                 = EnerPres
+
+tcoupl                   = V-rescale
+tc-grps                  = Protein  SOL
+tau-t                    = 0.1      0.1
+ref-t                    = 300      300
+
+pcoupl                   = Parrinello-Rahman
+tau-p                    = 2.0
+compressibility          = 4.5e-5
+ref-p                    = 1.0

--- a/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_no_print_set_correct.mdp
+++ b/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_no_print_set_correct.mdp
@@ -1,0 +1,31 @@
+integrator               = md
+dt                       = 0.002
+nsteps                   = 500000
+
+nstlog                   = 5000
+nstenergy                = 5000
+nstxout-compressed       = 5000
+
+continuation             = yes
+constraints              = all-bonds
+constraint-algorithm     = lincs
+
+cutoff-scheme            = Verlet
+
+coulombtype              = PME
+rcoulomb                 = 1.0
+
+vdwtype                  = Cut-off
+rvdw                     = 1.0
+DispCorr                 = EnerPres
+
+tcoupl                   = V-rescale
+tc-grps                  = Protein  SOL
+tau-t                    = 0.1      0.1
+ref-t                    = 300      300
+
+pcoupl                   = Parrinello-Rahman
+tau-p                    = 2.0
+compressibility          = 4.5e-5
+ref-p                    = 1.0
+gen-vel = no

--- a/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_print_set_correct.mdp
+++ b/transition_sampling/tests/engine_tests/gromacs_tests/test_data/mdp/good_input_print_set_correct.mdp
@@ -1,0 +1,32 @@
+integrator               = md
+dt                       = 0.002
+nsteps                   = 500000
+
+nstlog                   = 5000
+nstenergy                = 5000
+nstxout-compressed       = 5000
+
+continuation             = yes
+constraints              = all-bonds
+constraint-algorithm     = lincs
+
+cutoff-scheme            = Verlet
+
+coulombtype              = PME
+rcoulomb                 = 1.0
+
+vdwtype                  = Cut-off
+rvdw                     = 1.0
+DispCorr                 = EnerPres
+
+tcoupl                   = V-rescale
+tc-grps                  = Protein  SOL
+tau-t                    = 0.1      0.1
+ref-t                    = 300      300
+
+pcoupl                   = Parrinello-Rahman
+tau-p                    = 2.0
+compressibility          = 4.5e-5
+ref-p                    = 1.0
+gen-vel = no
+nstxout = 4

--- a/transition_sampling/tests/engine_tests/gromacs_tests/test_mdp.py
+++ b/transition_sampling/tests/engine_tests/gromacs_tests/test_mdp.py
@@ -1,0 +1,67 @@
+import filecmp
+import os
+import tempfile
+from unittest import TestCase
+
+from transition_sampling.engines.gromacs import MDPHandler
+
+CUR_DIR = os.path.dirname(__file__)
+MDP_DATA_DIR = os.path.join(CUR_DIR, "test_data/mdp")
+
+
+class TestReadTimeStep(TestCase):
+
+    def test_non_real_file(self):
+        """Test that a non-real file throws an exception"""
+        with self.assertRaises(ValueError, msg="non-existent file should raise exception"):
+            MDPHandler("not a real file.jpg")
+
+    def test_read_correct(self):
+        """Test that dt can correctly be read"""
+        mdp = MDPHandler(os.path.join(MDP_DATA_DIR, "good_input.mdp"))
+        self.assertEqual(2, mdp.timestep, msg="dt was not read correctly")
+
+    def test_read_default(self):
+        """Test that if no dt is present, the default is filled in"""
+        mdp = MDPHandler(os.path.join(MDP_DATA_DIR, "good_input_no_dt.mdp"))
+        self.assertEqual(1, mdp.timestep, msg="dt default not filled in")
+
+
+class TestWrite(TestCase):
+
+    def setUp(self) -> None:
+        """Open a tempfile to write output to during testing"""
+        self.tempfile = tempfile.NamedTemporaryFile()
+
+    def tearDown(self) -> None:
+        self.tempfile.close()
+
+    def test_invalid_set_print(self):
+        """Test that invalid print frequencies are denied"""
+        mdp = MDPHandler(os.path.join(MDP_DATA_DIR, "good_input.mdp"))
+        with self.assertRaises(ValueError, msg="Print freq cannot be negative"):
+            mdp.set_traj_print_freq(-1)
+
+        with self.assertRaises(ValueError, msg="Print freq must be an int"):
+            mdp.set_traj_print_freq(1.5)
+
+    def test_write_with_print_set(self):
+        """Test that file is written when print_freq is set"""
+        mdp = MDPHandler(os.path.join(MDP_DATA_DIR, "good_input.mdp"))
+        # write with the read value
+        mdp.set_traj_print_freq(2 * int(mdp.timestep))
+        mdp.write_mdp(self.tempfile.name)
+
+        correct = os.path.join(MDP_DATA_DIR, "good_input_print_set_correct.mdp")
+        self.assertTrue(filecmp.cmp(correct, self.tempfile.name, True),
+                        "Files are expected to be equal")
+
+    def test_write_no_print_set(self):
+        """Test that file is written correctly when print_freq not set"""
+        mdp = MDPHandler(os.path.join(MDP_DATA_DIR, "good_input.mdp"))
+        # write with the read value
+        mdp.write_mdp(self.tempfile.name)
+
+        correct = os.path.join(MDP_DATA_DIR, "good_input_no_print_set_correct.mdp")
+        self.assertTrue(filecmp.cmp(correct, self.tempfile.name, True),
+                        "Files are expected to be equal")


### PR DESCRIPTION
Adds code and tests for `MDPHandler`, which used to parse a template `.mdp` file, slightly modify it, and write it to disk as needed.