### PR TITLE
Refactor engines in prep for GROMACS

### DIFF
--- a/example/inputs.yml
+++ b/example/inputs.yml
@@ -6,7 +6,7 @@ md_inputs:
     engine_dir: '/FULL/FILE/PATH/transition-sampling/example/engine_working_dir/'
     # Command to launch the engine with. Can have anything proceeding (e.g. mpirun),
     # but no arguments should actually be given to the engine's binary
-    cmd: 'mpirun -n 1 -genv OMP_NUM_THREADS 1 /gscratch/pfaendtner/codes/cp2k/cp2k/cp2k/exe/Linux-x86-64-intel/cp2k.psmp'
+    md_cmd: 'mpirun -n 1 -genv OMP_NUM_THREADS 1 /gscratch/pfaendtner/codes/cp2k/cp2k/cp2k/exe/Linux-x86-64-intel/cp2k.psmp'
     # Path to plumed file containing COMMITTOR section with defined basins
     plumed_file: './input_files/plumed.dat'
     delta_t: 5   # Delta_t as defined in aimless shooting, in fs
@@ -24,6 +24,8 @@ md_inputs:
     # Prefix to the output names. Two files will be created, <output_name>.xyz and
     # <output_name>.csv. Note that this string should not include an extension.
     output_name: './result_files/results'
+    # temperature to generate velocities at in Kelvin
+    temp: 300.0
     # Number of aimless shootings to run in parallel. Total number of simulations
     # running at any given point is given by <n_parallel> * 2
     n_parallel: 4

--- a/example/main.py
+++ b/example/main.py
@@ -35,7 +35,7 @@ PLUMED_CMD = "mpirun plumed"
 # Inputs for the cp2k engine
 INPUTS = {"engine": "cp2k",
           "cp2k_inputs": CP2K_INPUT,
-          "cmd": CP2K_CMD,
+          "md_cmd": CP2K_CMD,
           "plumed_file": PLUMED_COMMITTOR,
           "delta_t": DELTA_T}
 

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -104,7 +104,8 @@ class AimlessShootingDriver:
             acceptor = copy.deepcopy(self.base_acceptor)
 
             logger = ResultsLogger(f"{self.log_name}{i}", base_logger)
-            algo = AsyncAimlessShooting(engine, self.position_dir, logger, acceptor)
+            algo = AsyncAimlessShooting(engine, self.position_dir, self.temp,
+                                        logger, acceptor)
 
             tasks.append(asyncio.create_task(algo.run(**run_args)))
 

--- a/transition_sampling/algo/aimless_shooting.py
+++ b/transition_sampling/algo/aimless_shooting.py
@@ -30,6 +30,8 @@ class AimlessShootingDriver:
         copies of it made for each parallel shooting.
     position_dir
         Directory containing starting xyz positions
+    temp
+        The temperature in Kelvin to generate initial velocities for
     log_name
         Base name for the log (csv and xyz) files. A call to run will generate
         `log_name`.csv and `log_name`.xyz files that hold results from all
@@ -47,15 +49,18 @@ class AimlessShootingDriver:
         Engine template to be used for all shootings
     position_dir : str
         Directory containing starting xyz positions to be used for all shootings
+    temp : float
+        The temperature in Kelvin to generate initial velocities for
     log_name : str
         Root name for all logging
     base_acceptor : AbstractAcceptor
         Acceptor template to be used for all shootings
     """
-    def __init__(self, engine: AbstractEngine, position_dir: str, log_name: str,
-                 acceptor: AbstractAcceptor = None):
+    def __init__(self, engine: AbstractEngine, position_dir: str, temp: float,
+                 log_name: str, acceptor: AbstractAcceptor = None):
         self.base_engine = engine
         self.position_dir = position_dir
+        self.temp = temp
         self.base_acceptor = acceptor
         self.log_name = log_name
 
@@ -119,6 +124,8 @@ class AsyncAimlessShooting:
     position_dir
         A directory containing only xyz positions of guesses at transition
         states. These positions will be used to try to kickstart the algorithm.
+    temp
+        The temperature in Kelvin to generate initial velocities for
     logger
         Logger to write xyz and csv results to. Use a logger with a defined
         `base_logger` to record these in more than one location.
@@ -134,6 +141,8 @@ class AsyncAimlessShooting:
         Engine used to run the simulations
     position_dir : str
         Directory containing initial xyz guesses of transition states.
+    temp : float
+        The temperature in Kelvin to generate initial velocities for
     current_offset : int
         -1, 0 or +1. The delta-t offset the point being run with engine
         currently represents for purposes of choosing the next point.
@@ -148,10 +157,11 @@ class AsyncAimlessShooting:
         An acceptor that implements an `is_accepted` method to determine if a
         shooting point should be considered accepted or not.
     """
-    def __init__(self, engine: AbstractEngine, position_dir: str,
+    def __init__(self, engine: AbstractEngine, position_dir: str, temp: float,
                  logger: ResultsLogger, acceptor: AbstractAcceptor = None):
         self.engine = engine
         self.position_dir = position_dir
+        self.temp = temp
         self.acceptor = acceptor
         self.logger = logger
 
@@ -340,7 +350,7 @@ class AsyncAimlessShooting:
         """
         for i in range(n_attempts):
             # Generate new velocities, run one point from it
-            vels = generate_velocities(self.engine.atoms, self.engine.temp)
+            vels = generate_velocities(self.engine.atoms, self.temp)
             # Set the position
             self.engine.set_positions(self.current_start)
             result = await self._run_one_velocity(vels)

--- a/transition_sampling/driver.py
+++ b/transition_sampling/driver.py
@@ -1,4 +1,5 @@
 import argparse
+import numbers
 import os
 
 from .colvar import PlumedDriver
@@ -87,6 +88,7 @@ def parse_aimless(aimless_inputs: dict, engine: AbstractEngine) -> AimlessShooti
 
     aimless_schema = Schema({"starts_dir": And(str, Use(check_is_dir)),
                              "output_name": str,
+                             "temp": And(numbers.Number, lambda x: x > 0, error="temp [K] must be > 0"),
                              "n_parallel": And(int, lambda x: x >= 1, error="n_parallel must be >= 1"),
                              "n_points": And(int, lambda x: x >= 1, error="n_points must be >= 1"),
                              "n_state_tries": And(int, lambda x: x >= 1, error="n_state_tries must be >= 1"),
@@ -119,7 +121,7 @@ def parse_aimless(aimless_inputs: dict, engine: AbstractEngine) -> AimlessShooti
     csv_file = f"{aimless_inputs['output_name']}.csv"
     xyz_file = f"{aimless_inputs['output_name']}.xyz"
 
-    return AimlessShootingDriver(engine, aimless_inputs["starts_dir"],
+    return AimlessShootingDriver(engine, aimless_inputs["starts_dir"], aimless_inputs["temp"],
                                  aimless_inputs["output_name"], acceptor)
 
 

--- a/transition_sampling/engines/abstract_engine.py
+++ b/transition_sampling/engines/abstract_engine.py
@@ -4,9 +4,11 @@ order to be used by the aimless shooting algorithm
 """
 from __future__ import annotations
 
+import asyncio
 import glob
 import numbers
 import os
+import uuid
 from abc import ABC, abstractmethod
 from typing import Sequence, Tuple
 
@@ -85,7 +87,7 @@ class AbstractEngine(ABC):
 
     Attributes
     ----------
-    cmd : list[str]
+    md_cmd : list[str]
         A list of tokens that when joined by spaces, represent the command to
         invoke the actual engine. Additional leading arguments such as mpirun
         can be included.
@@ -127,7 +129,7 @@ class AbstractEngine(ABC):
             raise ValueError(f"Invalid inputs: {validation_res[1]}")
 
         # Split command into a list of args
-        self.cmd = inputs["cmd"].split()
+        self.md_cmd = inputs["md_cmd"].split()
 
         # Create the plumed handler for the give plumed file
         self.plumed_handler = PlumedInputHandler(inputs["plumed_file"])
@@ -151,17 +153,6 @@ class AbstractEngine(ABC):
         Returns
         -------
         An ordered sequence of atoms in the engine.
-        """
-        pass
-
-    @property
-    @abstractmethod
-    def temp(self) -> float:
-        """Get the temperature of the engine in Kelvin.
-
-        Returns
-        -------
-        Temperature the engine is set to in Kelvin
         """
         pass
 
@@ -227,6 +218,11 @@ class AbstractEngine(ABC):
         pass
 
     @abstractmethod
+    def flip_velocity(self) -> None:
+        """Flip the velocities currently held by multiplying by -1"""
+        pass
+
+    @abstractmethod
     def validate_inputs(self, inputs: dict) -> Tuple[bool, str]:
         """Validate the given inputs for the specific engine.
 
@@ -249,11 +245,11 @@ class AbstractEngine(ABC):
         elif inputs["engine"].lower() != self.get_engine_str().lower():
             return False, "engine name does not match instantiated engine"
 
-        elif "cmd" not in inputs:
-            return False, "cmd must be specified in inputs"
+        elif "md_cmd" not in inputs:
+            return False, "md_cmd must be specified in inputs"
 
-        elif not isinstance(inputs["cmd"], str):
-            return False, "cmd must be a string of space separated cmdline args"
+        elif not isinstance(inputs["md_cmd"], str):
+            return False, "md_cmd must be a string of space separated cmdline args"
 
         elif "plumed_file" not in inputs:
             return False, "plumed_file must be specified in inputs"
@@ -269,7 +265,6 @@ class AbstractEngine(ABC):
 
         return True, ""
 
-    @abstractmethod
     async def run_shooting_point(self) -> ShootingResult:
         """Run the forward and reverse trajectories to get a shooting point.
 
@@ -289,6 +284,69 @@ class AbstractEngine(ABC):
         # TODO May be a way to turn them off
         for plumed_backup in glob.glob(f"{self.working_dir}/bck.*.PLUMED.OUT"):
             os.remove(plumed_backup)
+
+        # random project name so we don't overwrite/append anything
+        proj_name = uuid.uuid4().hex
+
+        tasks = (self._launch_traj_fwd(proj_name),
+                 self._launch_traj_rev(proj_name))
+
+        # Wait until both tasks are complete
+        result = await asyncio.gather(*tasks)
+        return ShootingResult(result[0], result[1])
+
+    async def _launch_traj_fwd(self, projname: str):
+        """Launch a trajectory in the forwards direction
+
+        For internal use by an implementing Engine class.
+
+        Parameters
+        ----------
+        projname
+            Root project name
+        """
+        return await self._launch_traj(projname + "_fwd")
+
+    async def _launch_traj_rev(self, projname: str):
+        """Launch a trajectory in the reverse direction
+
+        For internal use by an implementing Engine class.
+
+        Parameters
+        ----------
+        projname
+            Root project name
+        """
+        # Flip the velocity. This could cause an issue if we ever parallelize
+        # this method with shared memory, but shouldn't be a problem with a
+        # completely new proc or asyncio (current implementation)
+        self.flip_velocity()
+        return await self._launch_traj(projname + "_rev")
+
+    @abstractmethod
+    async def _launch_traj(self, projname: str) -> dict:
+        """Launch a trajectory with the current state to completion.
+
+        Launch a trajectory using the current state with the given md command in
+        a new process. Runs in the given working directory. Waits for its
+        completion with async, then checks for failures or warnings.
+
+        For internal use by an implementing Engine class.
+
+        Parameters
+        ----------
+        projname
+            The unique project name. No other project should have this name
+
+        Returns
+        -------
+        A dictionary with the keys:
+            "commit": basin integer the trajectory committed to or None if it
+                did not commit
+            "frames": np.array with the +delta_t and +2delta_t xyz frames. Has
+                the shape (2, n_atoms, 3)
+        """
+        pass
 
     @abstractmethod
     def set_delta_t(self, value: float) -> None:

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -54,10 +54,6 @@ class CP2KEngine(AbstractEngine):
         return self.cp2k_inputs.atoms
 
     @property
-    def temp(self) -> float:
-        return self.cp2k_inputs.temp
-
-    @property
     def box_size(self) -> tuple[float]:
         return tuple(self.cp2k_inputs.box_size)
 
@@ -72,6 +68,9 @@ class CP2KEngine(AbstractEngine):
         super().set_velocities(velocities)
 
         self.cp2k_inputs.set_velocities(velocities)
+
+    def flip_velocity(self) -> None:
+        self.cp2k_inputs.flip_velocity()
 
     def validate_inputs(self, inputs: dict) -> (bool, str):
         if "cp2k_inputs" not in inputs:
@@ -89,20 +88,6 @@ class CP2KEngine(AbstractEngine):
         # Otherwise let the base class validate
         return super().validate_inputs(inputs)
 
-    async def run_shooting_point(self) -> ShootingResult:
-        # Remove plumed backups
-        await super().run_shooting_point()
-
-        # random project name so we don't overwrite/append anything
-        proj_name = uuid.uuid4().hex
-
-        tasks = (self._launch_traj_fwd(proj_name),
-                 self._launch_traj_rev(proj_name))
-
-        # Wait until both tasks are complete
-        result = await asyncio.gather(*tasks)
-        return ShootingResult(result[0], result[1])
-
     def set_delta_t(self, value: float) -> None:
         # Make CP2K print trajectory after every delta_t amount of time rounded
         # to the nearest frame. We can then retrieve multiples of delta_t by
@@ -114,30 +99,6 @@ class CP2KEngine(AbstractEngine):
 
     def get_engine_str(self) -> str:
         return "cp2k"
-
-    async def _launch_traj_fwd(self, projname: str):
-        """Launch a trajectory in the forwards direction
-
-        Parameters
-        ----------
-        projname
-            Root project name
-        """
-        return await self._launch_traj(projname + "_fwd")
-
-    async def _launch_traj_rev(self, projname: str):
-        """Launch a trajectory in the reverse direction
-
-        Parameters
-        ----------
-        projname
-            Root project name
-        """
-        # Flip the velocity. This could cause an issue if we ever parallelize
-        # this method with shared memory, but shouldn't be a problem with a
-        # completely new proc or asyncio (current implementation)
-        self.cp2k_inputs.flip_velocity()
-        return await self._launch_traj(projname + "_rev")
 
     async def _launch_traj(self, projname: str) -> dict:
         """Launch a trajectory with the current state to completion.
@@ -188,7 +149,7 @@ class CP2KEngine(AbstractEngine):
         self.cp2k_inputs.write_cp2k_inputs(input_path)
 
         # Start cp2k, expanding the list of commands and setting input/output
-        proc = subprocess.Popen([*self.cmd, "-i", input_path, "-o",
+        proc = subprocess.Popen([*self.md_cmd, "-i", input_path, "-o",
                                  f"{projname}.out"],
                                 cwd=self.working_dir,
                                 stderr=subprocess.PIPE,

--- a/transition_sampling/tests/algo_tests/test_aimless_shooting.py
+++ b/transition_sampling/tests/algo_tests/test_aimless_shooting.py
@@ -18,7 +18,7 @@ class NextPositionTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
 
-            aimless = AsyncAimlessShooting(None, None, None)
+            aimless = AsyncAimlessShooting(None, None, 300, None)
             aimless.current_start = np.zeros((2, 3))
 
             fwd = {"commit": 1,

--- a/transition_sampling/tests/driver_tests/test_parsing.py
+++ b/transition_sampling/tests/driver_tests/test_parsing.py
@@ -11,7 +11,7 @@ class TestEngineParsing(unittest.TestCase):
     # Most inputs should be validated by the engine itself.
     VALID_INPUTS = {"engine": "cp2k",
                     "cp2k_inputs": os.path.join(CUR_DIR, "test_data/test_cp2k.inp"),
-                    "cmd": "cp2k_cmd",
+                    "md_cmd": "cp2k_cmd",
                     "plumed_file": os.path.join(CUR_DIR, "test_data/test_plumed.dat"),
                     "delta_t": 20,
                     "engine_dir": CUR_DIR}
@@ -34,6 +34,7 @@ class TestAimlessParsing(unittest.TestCase):
     # Most inputs should be validated by the engine itself.
     VALID_INPUTS = {"starts_dir": CUR_DIR,
                     "output_name": os.path.join(CUR_DIR, "test_data/input"),
+                    "temp": 300,
                     "n_parallel": 1,
                     "n_points": 1,
                     "n_state_tries": 1,
@@ -66,6 +67,15 @@ class TestAimlessParsing(unittest.TestCase):
 
     def test_output_name(self):
         self.inputs["output_name"] = 123
+        with self.assertRaises(SchemaError):
+            driver.parse_aimless(self.inputs, self.VALID_ENGINE)
+
+    def test_temperature(self):
+        self.inputs["temperature"] = -1
+        with self.assertRaises(SchemaError):
+            driver.parse_aimless(self.inputs, self.VALID_ENGINE)
+
+        self.inputs["temperature"] = "not a float"
         with self.assertRaises(SchemaError):
             driver.parse_aimless(self.inputs, self.VALID_ENGINE)
 

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_engine.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_engine.py
@@ -12,12 +12,12 @@ ENG_STR = "cp2k"
 CUR_DIR = os.path.dirname(__file__)
 TEST_INPUT = os.path.join(CUR_DIR, "test_data/test_cp2k.inp")
 TEST_PLUMED_FILE = os.path.join(CUR_DIR, "test_data/test_plumed.dat")
-TEST_CMD = "test cmd"
+TEST_CMD = "test md_cmd"
 TEST_DELTA_T = 20
 
 CORRECT_INPUTS = {"engine": ENG_STR,
                   "cp2k_inputs": TEST_INPUT,
-                  "cmd": TEST_CMD,
+                  "md_cmd": TEST_CMD,
                   "plumed_file": TEST_PLUMED_FILE,
                   "delta_t": 20}
 
@@ -122,22 +122,6 @@ class TestCP2KEngineAtoms(CP2KEngineTestCase):
             self.engine.atoms = ['Co', 'O']
 
 
-class TestCP2KEngineTemperature(CP2KEngineTestCase):
-    def test_temp_getting(self):
-        """
-        Test that the correct temperature is returned
-        """
-        self.assertAlmostEqual(85, self.engine.temp)
-
-    def test_temp_setting(self):
-        """
-        Test that temperature cannot be set
-        """
-        with self.assertRaises(AttributeError,
-                               msg="Temp should not be allowed assignment"):
-            self.engine.temp = 298
-
-
 class TestCP2KEngineBoxsize(CP2KEngineTestCase):
     def test_box_getting(self):
         """
@@ -218,3 +202,12 @@ class TestCP2KEngineVelocities(CP2KEngineTestCase):
         """
         vel = np.array([[1.0021, 123.123, 6.23123],
                         [8.12, 6.12381, 0.1232]])
+        self.engine.set_velocities(vel)
+
+    def test_velocities_flip(self):
+        vel = np.array([[1.0021, 123.123, 6.23123],
+                        [8.12, 6.12381, 0.1232]])
+
+        self.engine.set_velocities(vel)
+        self.engine.flip_velocity()  # No way to actually check without writing
+

--- a/transition_sampling/tests/engine_tests/test_abstract_engine.py
+++ b/transition_sampling/tests/engine_tests/test_abstract_engine.py
@@ -10,7 +10,7 @@ import numpy as np
 from transition_sampling.engines import AbstractEngine, ShootingResult
 
 TEST_ENG_STR = "TEST_ENGINE"
-TEST_CMD = "test cmd"
+TEST_CMD = "test md_cmd"
 CUR_DIR = os.path.dirname(__file__)
 TEST_PLUMED_FILE = os.path.join(CUR_DIR, "cp2k_tests/test_data/test_plumed.dat")
 
@@ -25,7 +25,7 @@ class AbstractEngineTestCase(TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.correct_inputs = {"engine": TEST_ENG_STR,
-                               "cmd": TEST_CMD,
+                               "md_cmd": TEST_CMD,
                                "plumed_file": TEST_PLUMED_FILE,
                                "delta_t": 20}
 
@@ -48,10 +48,6 @@ class AbstractEngineMock(AbstractEngine):
         return super().atoms
 
     @property
-    def temp(self) -> float:
-        return super().temp
-    
-    @property
     def box_size(self) -> tuple[float]:
         return super().box_size
 
@@ -60,6 +56,9 @@ class AbstractEngineMock(AbstractEngine):
 
     def set_velocities(self, velocities: np.ndarray) -> None:
         super().set_positions(velocities)
+
+    def flip_velocity(self) -> None:
+        pass
 
     def validate_inputs(self, inputs: dict) -> Tuple[bool, str]:
         return super().validate_inputs(inputs)
@@ -73,6 +72,9 @@ class AbstractEngineMock(AbstractEngine):
     def get_engine_str(self) -> str:
         return TEST_ENG_STR
 
+    async def _launch_traj(self, projname: str) -> dict:
+        pass
+
 
 class TestAbstractEngineValidation(AbstractEngineTestCase):
     def test_cmd(self):
@@ -80,12 +82,12 @@ class TestAbstractEngineValidation(AbstractEngineTestCase):
         Command should be a string
         """
         # Remove the command string
-        self.editable_inputs.pop("cmd")
+        self.editable_inputs.pop("md_cmd")
         with self.assertRaises(ValueError, msg="Empty engine name should fail"):
             e = AbstractEngineMock(self.editable_inputs)
 
         # set the command to be a number
-        self.editable_inputs["cmd"] = 10
+        self.editable_inputs["md_cmd"] = 10
         with self.assertRaises(ValueError, msg="Command needs to be a string"):
             e = AbstractEngineMock(self.editable_inputs)
 

--- a/transition_sampling/tests/integration_tests/algo_tests/test_algo_integration.py
+++ b/transition_sampling/tests/integration_tests/algo_tests/test_algo_integration.py
@@ -26,9 +26,11 @@ SINGLE_EXPECTED_DIR = os.path.join(CUR_DIR, "test_data/single")
 
 INPUTS = {"engine": "cp2k",
           "cp2k_inputs": TEST_INPUT,
-          "cmd": CP2K_CMD,
+          "md_cmd": CP2K_CMD,
           "plumed_file": TEST_PLUMED,
           "delta_t": 10}
+
+TEMP = 300
 
 
 class TestAimlessShootingIntegration(TestCase):
@@ -59,7 +61,7 @@ class TestAimlessShootingIntegration(TestCase):
             with tempfile.TemporaryDirectory() as engine_dir:
                 engine = CP2KEngine(INPUTS, engine_dir)
 
-                algo = AsyncAimlessShooting(engine, STARTS_DIR, logger)
+                algo = AsyncAimlessShooting(engine, STARTS_DIR, TEMP, logger)
 
                 # Run algorithm to generate 5 accepteds with 3 state attempts
                 # and 5 velocity attempts.
@@ -102,7 +104,7 @@ class TestAimlessShootingIntegration(TestCase):
             with tempfile.TemporaryDirectory() as engine_dir:
                 engine = CP2KEngine(INPUTS, engine_dir)
 
-                algo = AimlessShootingDriver(engine, STARTS_DIR, result_name)
+                algo = AimlessShootingDriver(engine, STARTS_DIR, TEMP, result_name)
 
                 # Run 3 parallel algorithms to generate 10 accepteds with 3
                 # state attempts and 5 velocity attempts.

--- a/transition_sampling/tests/integration_tests/end2end_tests/test_data/inputs.yml
+++ b/transition_sampling/tests/integration_tests/end2end_tests/test_data/inputs.yml
@@ -6,7 +6,7 @@ md_inputs:
     engine_dir: './working_dir'
     # Command to launch the engine with. Can have anything proceeding (e.g. mpirun),
     # but no arguments should actually be given to the engine's binary
-    cmd: "/src/cp2k.ssmp"
+    md_cmd: "/src/cp2k.ssmp"
     # Path to plumed file containing COMMITTOR section with defined basins
     plumed_file: '../shared_test_data/plumed.dat'
     delta_t: 10   # Delta_t as defined in aimless shooting, in fs

--- a/transition_sampling/tests/integration_tests/end2end_tests/test_data/inputs.yml
+++ b/transition_sampling/tests/integration_tests/end2end_tests/test_data/inputs.yml
@@ -24,6 +24,8 @@ md_inputs:
     # Prefix to the output names. Two files will be created, <output_name>.xyz and
     # <output_name>.csv. Note that this string should not include an extension.
     output_name: './working_dir/results'
+    # temperature to generate velocities at in Kelvin
+    temp: 300.0
     # Number of aimless shootings to run in parallel. Total number of simulations
     # running at any given point is given by <n_parallel> * 2
     n_parallel: 4

--- a/transition_sampling/tests/integration_tests/engine_tests/test_engine_integration.py
+++ b/transition_sampling/tests/integration_tests/engine_tests/test_engine_integration.py
@@ -23,7 +23,7 @@ RESULTS = os.path.join(CUR_DIR, "test_data/results.pkl")
 
 INPUTS = {"engine": "cp2k",
           "cp2k_inputs": TEST_INPUT,
-          "cmd": CP2K_CMD,
+          "md_cmd": CP2K_CMD,
           "plumed_file": TEST_PLUMED,
           "delta_t": 10}
 


### PR DESCRIPTION
These are the refactors we discussed earlier today. They are:
- rename `cmd` to `md_cmd` to be more verbose and allow for other commands
- move temperature parameter from the engine's responsibility of reading the MD input files to Aimless Shooting's responsibility in `inputs.yml`. This kinda makes more sense anyways, as Aimless Shooting is what's using the temperature to generate velocities, not the engine. I've left the capability to read the temperature from the CP2K file in `CP2KInputsHandler` and maybe we could give some type of warning if they don't align
- The concrete methods of `run_shooting_point, _launch_traj_fwd, launch_traj_rev` have all been moved into the `AbstractEngine` because I found they were exactly the same for GROMACS. Instead, engine implementations will just override `_launch_traj` with their specific command. I've also pulled out another method for them to override `flip_velocity` to facilitate this.

This will have merge conflicts with the current PR for logging, but I'll merge manually when we get there