### PR TITLE
Subsitute arguments into a command with a special string

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 MD Engine Agnostic Implementation of Aimless-Shooting Likelihood Maximization [Peters and Trout 
 [doi:10.1063/1.2234477](https://aip.scitation.org/doi/10.1063/1.2234477)]
+
+See the main documentation at https://uwprg.github.io/transition-sampling/

--- a/docs/source/engines/engines.rst
+++ b/docs/source/engines/engines.rst
@@ -31,6 +31,13 @@ the inputs. In particular, these are
     up to the path of the engine executable. Any additional commands (such as ``mpirun``)
     can be prepended, but the final argument should be the engine executable.
 
+    If your engine command is more complicated, such being wrapped in quotes or
+    needing multiple commands chained together, you can use argument substitution.
+    This allows exact specification of where arguments should be placed, **and
+    executes in shell mode**, allowing operators like ``&&`` or ``|`` that would
+    otherwise produce bad input. This is done placing the ``%CMD_ARGS%`` where
+    the engine arguments should be substituted
+
     ..  warning::
         You should not rely on relative paths of executables. They should either be
         in the PATH environment variable when invoked, or the full path should be given.
@@ -39,15 +46,23 @@ the inputs. In particular, these are
 
     * ``"md_cmd": "/path/to/cp2k/exec"`` - just use the standard cp2k executable.
     * ``"md_cmd": "mpirun -n 2 -genv 1 /path/to/cp2k/exec"`` -  Run cp2k with MPI with two processes
+    * ``"md_cmd": "echo 'hello there' && /path/to/cp2k/exec %CMD_ARGS%"`` - Running chained commands requires using argument substitution
+    * ``"md_cmd": "sbatch -n 2 --wrap '/path/to/cp2k/exec %CMD_ARGS%'`` - Exact placement of arguments requires using argument substitution
 
         ..  note::
             Since the aimless shooting algorithm runs the forwards and backwards trajectories
             in parallel, the ideal number of MPI processes is equal to ``num_cores/2``, so
-            cores are distributed evenly across the two trajectories.
+            cores are distributed evenly across the two trajectories. (Assuming resources are
+            shared).
 
     Examples of **invalid** commands:
 
     * ``"md_cmd": "/path/to/cp2k/exec -i my_input_file -o my_output_file"`` - arguments after the engine executable should be left to the module
+    * ``"md_cmd": "echo 'hello there' && /path/to/cp2k/exec"`` - Shell specific operators such as ``&&`` will not work without argument substitution
+
+    .. hint::
+        Using ``aimless_driver --log-level DEBUG`` will log the commands used
+        to launch each trajectory and can be useful in debugging.
 
 ``plumed_file`` - the path to the `PLUMED <https://www.plumed.org/>`_ file with the committor basins for the system
     The plumed file that defines the basins associated with a complete reaction. This should
@@ -74,3 +89,4 @@ the inputs. In particular, these are
 
         d1:  DISTANCE ATOMS=1,2
         COMMITTOR ARG=d1 BASIN_LL1=0 BASIN_UL1=.15 BASIN_LL2=1 BASIN_UL2=100
+

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -155,18 +155,9 @@ class CP2KEngine(AbstractEngine):
         input_path = os.path.join(self.working_dir, f"{projname}.inp")
         self.cp2k_inputs.write_cp2k_inputs(input_path)
 
-        command_list = [*self.md_cmd, "-i", input_path, "-o", f"{projname}.out"]
-        self.logger.debug("Launching trajectory %s with command %s", projname, command_list)
-
-        # Start cp2k, expanding the list of commands and setting input/output
-        proc = subprocess.Popen(command_list, cwd=self.working_dir,
-                                stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE)
-
-        # Wait for it to finish
-        while proc.poll() is None:
-            # Non-blocking sleep
-            await asyncio.sleep(1)
+        # run
+        proc = await self._open_process_and_wait(
+            ["-i", input_path, "-o", f"{projname}.out"], projname)
 
         # Create an output handler for errors and warnings
         output_handler = CP2KOutputHandler(projname, self.working_dir)

--- a/transition_sampling/engines/cp2k/CP2K_engine.py
+++ b/transition_sampling/engines/cp2k/CP2K_engine.py
@@ -156,7 +156,7 @@ class CP2KEngine(AbstractEngine):
         self.cp2k_inputs.write_cp2k_inputs(input_path)
 
         # run
-        proc = await self._open_process_and_wait(
+        proc = await self._open_md_and_wait(
             ["-i", input_path, "-o", f"{projname}.out"], projname)
 
         # Create an output handler for errors and warnings

--- a/transition_sampling/engines/gromacs/gromacs_engine.py
+++ b/transition_sampling/engines/gromacs/gromacs_engine.py
@@ -214,17 +214,10 @@ class GromacsEngine(AbstractEngine):
                                       f"{projname}_plumed.dat")
         self.plumed_handler.write_plumed(plumed_in_path, plumed_out_name)
 
-        command_list = [*self.md_cmd, "-s", tpr_path, "-plumed", plumed_in_path,
-                        "-deffnm", projname]
-        self.logger.debug("Launching trajectory %s with command %s", projname, command_list)
-        proc = subprocess.Popen(command_list, cwd=self.working_dir,
-                                stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE)
-
-        # Wait for it to finish
-        while proc.poll() is None:
-            # Non-blocking sleep
-            await asyncio.sleep(1)
+        # run
+        proc = await self._open_process_and_wait(
+            ["-s", tpr_path, "-plumed", plumed_in_path, "-deffnm", projname],
+            projname)
 
         plumed_out_path = os.path.join(self.working_dir, plumed_out_name)
         # Check if there was a fatal error that wasn't caused by a committing

--- a/transition_sampling/engines/gromacs/gromacs_engine.py
+++ b/transition_sampling/engines/gromacs/gromacs_engine.py
@@ -215,7 +215,7 @@ class GromacsEngine(AbstractEngine):
         self.plumed_handler.write_plumed(plumed_in_path, plumed_out_name)
 
         # run
-        proc = await self._open_process_and_wait(
+        proc = await self._open_md_and_wait(
             ["-s", tpr_path, "-plumed", plumed_in_path, "-deffnm", projname],
             projname)
 

--- a/transition_sampling/tests/engine_tests/test_abstract_engine.py
+++ b/transition_sampling/tests/engine_tests/test_abstract_engine.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import os
+import subprocess
 from typing import Tuple, Sequence
-from unittest import TestCase
+from unittest import TestCase, mock
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 
@@ -22,6 +25,7 @@ class AbstractEngineTestCase(TestCase):
     to an "editable inputs" that are allowed to be modified in whatever way the
     test needs.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.correct_inputs = {"engine": TEST_ENG_STR,
@@ -137,3 +141,58 @@ class TestCP2KEngineWorkingDirectory(AbstractEngineTestCase):
     def test_working_dir_is_set(self):
         e = AbstractEngineMock(self.correct_inputs, CUR_DIR)
         self.assertEqual(e.working_dir, CUR_DIR)
+
+    @patch("subprocess.Popen")
+    def test_launched_in_working_dir(self, popen_mock):
+        e = AbstractEngineMock(self.correct_inputs, CUR_DIR)
+        asyncio.run(e._open_md_and_wait([], ""))
+        popen_mock.assert_called_with(mock.ANY,
+                                      cwd=CUR_DIR, shell=mock.ANY,
+                                      stderr=subprocess.PIPE,
+                                      stdout=subprocess.PIPE)
+
+
+class TestAbstractEngineOpenMDAndWait(AbstractEngineTestCase):
+    @patch("subprocess.Popen")
+    def test_correct_cmd_no_sub(self, popen_mock: MagicMock):
+        e = AbstractEngineMock(self.correct_inputs)
+        cmd_args = ["-i", "test_arg"]
+        asyncio.run(e._open_md_and_wait(cmd_args, ""))
+        popen_mock.assert_called_with(TEST_CMD.split() + cmd_args,
+                                      cwd=".", shell=False,
+                                      stderr=subprocess.PIPE,
+                                      stdout=subprocess.PIPE)
+
+    @patch("subprocess.Popen")
+    def test_correct_cmd_sub_without_quotes(self, popen_mock: MagicMock):
+        self.editable_inputs["md_cmd"] = "command %CMD_ARGS%"
+        e = AbstractEngineMock(self.editable_inputs)
+        cmd_args = ["-i", "test_arg"]
+        asyncio.run(e._open_md_and_wait(cmd_args, ""))
+        popen_mock.assert_called_with("command -i test_arg",
+                                      cwd=".", shell=True,
+                                      stderr=subprocess.PIPE,
+                                      stdout=subprocess.PIPE)
+
+    @patch("subprocess.Popen")
+    def test_correct_cmd_sub_with_quotes(self, popen_mock: MagicMock):
+        self.editable_inputs["md_cmd"] = 'command "put args here %CMD_ARGS%"'
+        e = AbstractEngineMock(self.editable_inputs)
+        cmd_args = ["-i", "test_arg"]
+        asyncio.run(e._open_md_and_wait(cmd_args, ""))
+        popen_mock.assert_called_with('command "put args here -i test_arg"',
+                                      cwd=".", shell=True,
+                                      stderr=subprocess.PIPE,
+                                      stdout=subprocess.PIPE)
+
+    @patch("subprocess.Popen")
+    def test_returns_process_after_waiting(self, popen_mock: MagicMock):
+        e = AbstractEngineMock(self.correct_inputs)
+        process_mock = mock.Mock()
+        # first poll, not finished. At second poll, it is finished and will
+        # return
+        process_mock.poll.side_effect = [None, True]
+        popen_mock.return_value = process_mock
+        result = asyncio.run(e._open_md_and_wait([], ""))
+        # make sure we get back what we gave it
+        self.assertEqual(result, process_mock)


### PR DESCRIPTION
Adds a new feature where the `md_cmd` can optionally include the string `%CMD_ARGS%`. If this string is found, the arguments that aimless shooting needs to give the MD engine will directly replace it. Furthermore, the command will execute in shell mode, allowing shell commands like `|`, `&&`, and environment variables to be used. If this string is not found, the command is executed in the exact same way as before

The primary purpose of this change is to allow chained commands, or commands that need to be enclosed by quotes, such as `sbatch .... --wrap "mpirun cp2k.psmp %CMD_ARGS%". 

Unit tests and user documentation has been updated.