### PR TITLE
Update for newest cp2k-*-tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cp2k-input-tools~=0.5.1
-cp2k-output-tools~=0.3.1
+cp2k-input-tools
+cp2k-output-tools
 numpy
 pandas
 mdtraj

--- a/transition_sampling/engines/cp2k/CP2K_outputs.py
+++ b/transition_sampling/engines/cp2k/CP2K_outputs.py
@@ -36,8 +36,12 @@ class CP2KOutputHandler:
         with open(self.get_out_file(), "r") as f:
             warnings = match_warnings(f.read())
 
+        # cp2k-output-tools >= v0.4.0
+        # if an early version of cp2k-output-tools is installed by mistake,
+        # remove the .data
         # remove warnings about truncation for paths that are too long
-        return [warn for warn in warnings['warnings'] if "val_get will truncate" not in warn["message"]]
+        return [warn for warn in warnings.data['warnings']
+                if "val_get will truncate" not in warn["message"]]
 
     def get_out_file(self) -> str:
         """Get the full name of the output file

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_inputs.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_inputs.py
@@ -135,7 +135,7 @@ class TestCP2KInputsVelocities(CP2KInputsTestCase):
         for s, v in zip(actual, expected):
             # Convert numpy array to list for assertListEquals
             v = v.tolist()
-            self.assertListEqual(v, s, "Velocities were not equal")
+            self.assertSequenceEqual(v, s, "Velocities were not equal")
 
 
 class TestCP2KInputsWritePlumed(CP2KInputsTestCase):

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_outputs.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_outputs.py
@@ -30,7 +30,6 @@ class TestCP2KOutputHandler(TestCase):
                                         temp_file.name), "files were not equal")
 
     def test_output_handler_catches_warnings(self):
-        print(self.out_handler.check_warnings())
         self.assertEqual(len(self.out_handler.check_warnings()), 1,
                          "Warnings were not caught")
 

--- a/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_outputs.py
+++ b/transition_sampling/tests/engine_tests/cp2k_tests/test_CP2K_outputs.py
@@ -30,6 +30,7 @@ class TestCP2KOutputHandler(TestCase):
                                         temp_file.name), "files were not equal")
 
     def test_output_handler_catches_warnings(self):
+        print(self.out_handler.check_warnings())
         self.assertEqual(len(self.out_handler.check_warnings()), 1,
                          "Warnings were not caught")
 


### PR DESCRIPTION
The latest releases of `cp2k-input-tools` and `cp2k-output-tools` broke some simple stuff. This fixes it and removes the version requirements